### PR TITLE
Redesign main site (Encord-inspired dark theme) + add humanoid subsite

### DIFF
--- a/humanoid/HumanoidCohort.jsx
+++ b/humanoid/HumanoidCohort.jsx
@@ -1,0 +1,1023 @@
+import React, { useState } from "react";
+import {
+  ArrowRight,
+  Cpu,
+  Cog,
+  Brain,
+  Bot,
+  Wrench,
+  Cable,
+  Camera,
+  Battery,
+  FlaskConical,
+  Eye,
+  GraduationCap,
+  Sparkles,
+  Calendar,
+  Clock,
+  Users,
+  Award,
+  ChevronDown,
+  Check,
+  Zap,
+  ScrollText,
+  Github,
+  Mail,
+  MapPin,
+  ShieldCheck,
+} from "lucide-react";
+
+/* -------------------------------------------------------------------------- */
+/*                                  CONTENT                                   */
+/* -------------------------------------------------------------------------- */
+
+const PLATFORM_PILLARS = [
+  {
+    id: "me",
+    label: "Mechanical Engineering",
+    tag: "ME",
+    icon: Cog,
+    accent: "from-emerald-400/20 to-emerald-400/0",
+    ring: "ring-emerald-400/30",
+    iconColor: "text-emerald-300",
+    headline: "30 Active Degrees of Freedom",
+    body:
+      "7 DoF per arm, 6 per leg, 2 in the neck, 2 in the waist. Ultra-robust 3D-printed structural components engineered for repeated drops, falls, and self-recovery.",
+    bullets: [
+      "Anthropomorphic 30-DoF kinematics",
+      "Dynamixel-class actuator integration",
+      "Print-in-place tolerancing & assembly",
+    ],
+  },
+  {
+    id: "ee",
+    label: "Electrical Engineering",
+    tag: "EE",
+    icon: Cable,
+    accent: "from-sky-400/20 to-sky-400/0",
+    ring: "ring-sky-400/30",
+    iconColor: "text-sky-300",
+    headline: "Jetson Orin NX Onboard Compute",
+    body:
+      "Stereo fisheye perception, custom power management, and a clean serial bus topology — production-grade electrical design, not a hobby breadboard.",
+    bullets: [
+      "Stereo fisheye camera pipeline",
+      "Custom DC power distribution",
+      "Smart-bus actuator daisy-chain",
+    ],
+  },
+  {
+    id: "ai",
+    label: "Computer Science & AI",
+    tag: "CS / AI",
+    icon: Brain,
+    accent: "from-emerald-400/15 via-sky-400/10 to-sky-400/0",
+    ring: "ring-emerald-400/30",
+    iconColor: "text-emerald-300",
+    headline: "Sim-to-Real Reinforcement Learning",
+    body:
+      "Build a faithful MuJoCo / MJX digital twin, identify system dynamics, and train RL walking policies that transfer to the real chassis.",
+    bullets: [
+      "MuJoCo + MJX physics simulation",
+      "System identification (sysID)",
+      "RL omnidirectional locomotion",
+    ],
+  },
+];
+
+const PHASES = [
+  {
+    id: "summer",
+    title: "Summer Intensive",
+    subtitle: "The Physical Build",
+    duration: "8 Weeks",
+    cadence: "Jun – Aug",
+    icon: Wrench,
+    milestone:
+      "Assemble the complete 30-DoF chassis, wire every electronic subsystem, calibrate joint zero-points, and deploy Python keyframe scripts so the robot performs open-loop push-ups and squats.",
+    deliverables: [
+      "Fully-assembled humanoid chassis",
+      "Calibrated actuator bus & power rails",
+      "Open-loop keyframe motion demos",
+    ],
+  },
+  {
+    id: "fall",
+    title: "Fall Academy",
+    subtitle: "The Digital Brain",
+    duration: "12 Weeks",
+    cadence: "Sep – Dec",
+    icon: Brain,
+    milestone:
+      "Stand up a MuJoCo digital twin, perform motor system identification, train RL walking policies in MJX, and explore real-time VR teleoperation or vision-based manipulation.",
+    deliverables: [
+      "MuJoCo digital twin + sysID report",
+      "Trained RL walking policy",
+      "Teleop or manipulation capstone demo",
+    ],
+  },
+];
+
+const SYLLABUS = [
+  {
+    weeks: "Weeks 1–2",
+    title: "Anthropomorphic Design & 3D Printing Tolerances",
+    blurb:
+      "How humanoid linkages distribute mass, why tolerance stacks dominate joint feel, and how to print structural parts that survive a fall.",
+    icon: Cog,
+    phase: "Summer",
+  },
+  {
+    weeks: "Weeks 3–4",
+    title: "Actuator Calibration, Bus Comms & Power Schematics",
+    blurb:
+      "Read datasheets like an engineer. Build a clean serial-bus topology, set actuator IDs, and design a power distribution diagram that won't brown-out under load.",
+    icon: Cable,
+    phase: "Summer",
+  },
+  {
+    weeks: "Weeks 5–6",
+    title: "Full Chassis Mechatronics & Jetson Orin NX Setup",
+    blurb:
+      "Mate the printed skeleton, route every cable, flash the Jetson, and stand up the on-robot software stack end-to-end.",
+    icon: Cpu,
+    phase: "Summer",
+  },
+  {
+    weeks: "Weeks 7–8",
+    title: "Kinematics & Python Keyframe Motion Control",
+    blurb:
+      "Forward kinematics, joint-space trajectories, and a keyframe app that drives the real hardware. Summer milestone: live push-ups and squats.",
+    icon: Bot,
+    phase: "Summer",
+    milestone: true,
+  },
+  {
+    weeks: "Weeks 9–12",
+    title: "Digital Twins in MuJoCo & System Identification",
+    blurb:
+      "Build the simulated twin of your own robot, then identify its true dynamics so simulation actually predicts reality.",
+    icon: FlaskConical,
+    phase: "Fall",
+  },
+  {
+    weeks: "Weeks 13–16",
+    title: "RL: Omnidirectional Locomotion Policies in MJX",
+    blurb:
+      "PPO-style reinforcement learning, reward shaping, and large-scale parallel rollouts in MJX to train a policy that walks.",
+    icon: Brain,
+    phase: "Fall",
+  },
+  {
+    weeks: "Weeks 17–20",
+    title: "Sim-to-Real Transfer, Evaluation & Portfolio Presentation",
+    blurb:
+      "Deploy your policy on the physical robot, measure the reality gap, and produce a research-quality writeup for your portfolio.",
+    icon: GraduationCap,
+    phase: "Fall",
+    milestone: true,
+  },
+];
+
+/* -------------------------------------------------------------------------- */
+/*                              SHARED PRIMITIVES                             */
+/* -------------------------------------------------------------------------- */
+
+function SectionLabel({ children }) {
+  return (
+    <div className="inline-flex items-center gap-2 text-xs font-mono uppercase tracking-[0.2em] text-emerald-300/90">
+      <span className="h-1.5 w-1.5 rounded-full bg-emerald-400 shadow-[0_0_12px_2px_rgba(52,211,153,0.7)]" />
+      {children}
+    </div>
+  );
+}
+
+function GlassCard({ className = "", children }) {
+  return (
+    <div
+      className={`relative rounded-2xl border border-white/10 bg-white/[0.03] backdrop-blur-xl shadow-[0_1px_0_0_rgba(255,255,255,0.05)_inset] transition-all duration-300 hover:border-white/20 hover:bg-white/[0.05] ${className}`}
+    >
+      {children}
+    </div>
+  );
+}
+
+function PrimaryButton({ href = "#apply", children, className = "" }) {
+  return (
+    <a
+      href={href}
+      className={`group relative inline-flex items-center justify-center gap-2 rounded-xl px-6 py-3.5 text-sm font-semibold text-slate-950 transition-all duration-300 ${className}`}
+    >
+      <span className="absolute inset-0 rounded-xl bg-gradient-to-r from-emerald-400 via-emerald-300 to-sky-400" />
+      <span className="absolute inset-0 rounded-xl bg-gradient-to-r from-emerald-400 via-emerald-300 to-sky-400 opacity-70 blur-xl transition-opacity duration-300 group-hover:opacity-100" />
+      <span className="relative flex items-center gap-2">
+        {children}
+        <ArrowRight className="h-4 w-4 transition-transform duration-300 group-hover:translate-x-0.5" />
+      </span>
+    </a>
+  );
+}
+
+function SecondaryButton({ href = "#syllabus", children, className = "" }) {
+  return (
+    <a
+      href={href}
+      className={`group inline-flex items-center justify-center gap-2 rounded-xl border border-white/15 bg-white/[0.03] px-6 py-3.5 text-sm font-semibold text-white backdrop-blur-md transition-all duration-300 hover:border-emerald-400/40 hover:bg-white/[0.06] hover:text-emerald-200 ${className}`}
+    >
+      {children}
+      <ArrowRight className="h-4 w-4 opacity-60 transition-all duration-300 group-hover:translate-x-0.5 group-hover:opacity-100" />
+    </a>
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/*                                    NAV                                     */
+/* -------------------------------------------------------------------------- */
+
+function Nav() {
+  return (
+    <header className="fixed inset-x-0 top-0 z-50 border-b border-white/5 bg-slate-950/60 backdrop-blur-xl">
+      <div className="mx-auto flex max-w-7xl items-center justify-between px-6 py-4">
+        <a href="#" className="group flex items-center gap-2.5">
+          <span className="relative grid h-9 w-9 place-items-center rounded-lg bg-gradient-to-br from-emerald-400 to-sky-500 text-slate-950 shadow-[0_0_24px_-4px_rgba(52,211,153,0.6)]">
+            <Bot className="h-5 w-5" strokeWidth={2.4} />
+          </span>
+          <div className="leading-tight">
+            <div className="text-sm font-semibold text-white">Genboo · Humanoid</div>
+            <div className="font-mono text-[10px] uppercase tracking-[0.18em] text-slate-400">
+              humanoid.genboo.com
+            </div>
+          </div>
+        </a>
+
+        <nav className="hidden items-center gap-8 md:flex">
+          {[
+            { href: "#platform", label: "Platform" },
+            { href: "#program", label: "Program" },
+            { href: "#syllabus", label: "Syllabus" },
+            { href: "#mentorship", label: "Mentorship" },
+          ].map((item) => (
+            <a
+              key={item.href}
+              href={item.href}
+              className="text-sm text-slate-300 transition-colors hover:text-emerald-300"
+            >
+              {item.label}
+            </a>
+          ))}
+        </nav>
+
+        <PrimaryButton className="hidden md:inline-flex" href="#apply">
+          Apply
+        </PrimaryButton>
+      </div>
+    </header>
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/*                                    HERO                                    */
+/* -------------------------------------------------------------------------- */
+
+function Hero() {
+  return (
+    <section className="relative overflow-hidden pt-36 pb-24 md:pt-44 md:pb-32">
+      {/* ambient glows */}
+      <div className="pointer-events-none absolute inset-0 -z-10">
+        <div className="absolute -top-32 left-1/2 h-[36rem] w-[36rem] -translate-x-1/2 rounded-full bg-emerald-500/20 blur-[140px]" />
+        <div className="absolute right-[-10rem] top-40 h-[28rem] w-[28rem] rounded-full bg-sky-500/15 blur-[140px]" />
+        <div className="absolute left-[-10rem] bottom-[-10rem] h-[28rem] w-[28rem] rounded-full bg-emerald-400/10 blur-[140px]" />
+      </div>
+
+      {/* dot grid */}
+      <div
+        className="pointer-events-none absolute inset-0 -z-10 opacity-[0.18]"
+        style={{
+          backgroundImage:
+            "radial-gradient(circle at 1px 1px, rgba(255,255,255,0.35) 1px, transparent 0)",
+          backgroundSize: "28px 28px",
+          maskImage:
+            "radial-gradient(ellipse 80% 60% at 50% 30%, #000 40%, transparent 100%)",
+        }}
+      />
+
+      <div className="mx-auto max-w-7xl px-6">
+        <div className="flex flex-col items-center text-center">
+          <div className="mb-7 inline-flex items-center gap-2 rounded-full border border-emerald-400/30 bg-emerald-400/5 px-4 py-1.5 text-xs font-mono uppercase tracking-[0.18em] text-emerald-200">
+            <span className="relative flex h-2 w-2">
+              <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-emerald-400 opacity-75" />
+              <span className="relative inline-flex h-2 w-2 rounded-full bg-emerald-400" />
+            </span>
+            Cohort 01 · Now Accepting Applications
+          </div>
+
+          <h1 className="max-w-5xl text-balance bg-gradient-to-br from-white via-white to-slate-400 bg-clip-text text-4xl font-bold leading-[1.05] tracking-tight text-transparent sm:text-5xl md:text-6xl lg:text-7xl">
+            Build a Humanoid Robot From Scratch.
+            <br className="hidden md:block" />
+            <span className="bg-gradient-to-r from-emerald-300 via-emerald-200 to-sky-300 bg-clip-text text-transparent">
+              {" "}Master ME, EE, and AI.
+            </span>
+          </h1>
+
+          <p className="mt-7 max-w-3xl text-pretty text-base leading-relaxed text-slate-300 md:text-lg">
+            An elite <span className="font-semibold text-white">20-week cohort</span> for high
+            school students to construct, simulate, and train{" "}
+            <span className="font-semibold text-emerald-300">ToddlerBot</span> — the open-source,
+            ML-compatible humanoid platform. Mentored by Genboo engineers with direct technical
+            consultation from the paper's original 1st and 2nd authors.
+          </p>
+
+          <div className="mt-10 flex flex-col items-center gap-3 sm:flex-row sm:gap-4">
+            <PrimaryButton href="#apply">Apply for the Cohort</PrimaryButton>
+            <SecondaryButton href="#syllabus">
+              <ScrollText className="h-4 w-4" />
+              View Syllabus
+            </SecondaryButton>
+          </div>
+
+          {/* spec strip */}
+          <div className="mt-14 grid w-full max-w-4xl grid-cols-2 gap-px overflow-hidden rounded-2xl border border-white/10 bg-white/[0.02] sm:grid-cols-4">
+            {[
+              { k: "20", label: "Weeks" },
+              { k: "30", label: "Active DoFs" },
+              { k: "6 hr", label: "Per Week" },
+              { k: "1:5", label: "Mentor Ratio" },
+            ].map((stat) => (
+              <div
+                key={stat.label}
+                className="bg-slate-950/60 px-6 py-5 text-center backdrop-blur-md"
+              >
+                <div className="bg-gradient-to-b from-white to-slate-400 bg-clip-text text-3xl font-bold text-transparent">
+                  {stat.k}
+                </div>
+                <div className="mt-1 font-mono text-[10px] uppercase tracking-[0.18em] text-slate-400">
+                  {stat.label}
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/*                             PLATFORM HIGHLIGHTS                            */
+/* -------------------------------------------------------------------------- */
+
+function Platform() {
+  return (
+    <section id="platform" className="relative py-24 md:py-32">
+      <div className="mx-auto max-w-7xl px-6">
+        <div className="mx-auto max-w-3xl text-center">
+          <SectionLabel>The Platform</SectionLabel>
+          <h2 className="mt-5 text-balance text-3xl font-bold tracking-tight text-white md:text-5xl">
+            A research-grade humanoid,{" "}
+            <span className="bg-gradient-to-r from-emerald-300 to-sky-300 bg-clip-text text-transparent">
+              not a toy kit.
+            </span>
+          </h2>
+          <p className="mt-5 text-pretty text-base leading-relaxed text-slate-300 md:text-lg">
+            ToddlerBot is the Stanford-published, open-source humanoid platform you'll build, wire,
+            and teach to walk. Every component is portfolio-grade.
+          </p>
+        </div>
+
+        <div className="mt-16 grid gap-6 lg:grid-cols-3">
+          {PLATFORM_PILLARS.map((pillar) => {
+            const Icon = pillar.icon;
+            return (
+              <GlassCard
+                key={pillar.id}
+                className="group overflow-hidden p-7 hover:-translate-y-1"
+              >
+                <div
+                  className={`pointer-events-none absolute -inset-px rounded-2xl bg-gradient-to-b ${pillar.accent} opacity-0 transition-opacity duration-500 group-hover:opacity-100`}
+                />
+                <div className="relative">
+                  <div className="flex items-center justify-between">
+                    <div
+                      className={`grid h-12 w-12 place-items-center rounded-xl bg-white/5 ring-1 ${pillar.ring}`}
+                    >
+                      <Icon className={`h-6 w-6 ${pillar.iconColor}`} strokeWidth={1.8} />
+                    </div>
+                    <span className="font-mono text-[10px] uppercase tracking-[0.18em] text-slate-400">
+                      {pillar.tag}
+                    </span>
+                  </div>
+
+                  <div className="mt-7">
+                    <div className="text-xs font-mono uppercase tracking-[0.18em] text-slate-400">
+                      {pillar.label}
+                    </div>
+                    <h3 className="mt-2 text-xl font-semibold leading-tight text-white">
+                      {pillar.headline}
+                    </h3>
+                    <p className="mt-3 text-sm leading-relaxed text-slate-300">{pillar.body}</p>
+                  </div>
+
+                  <ul className="mt-6 space-y-2.5 border-t border-white/5 pt-5">
+                    {pillar.bullets.map((b) => (
+                      <li
+                        key={b}
+                        className="flex items-start gap-2.5 text-sm text-slate-300"
+                      >
+                        <Check
+                          className={`mt-0.5 h-4 w-4 flex-shrink-0 ${pillar.iconColor}`}
+                          strokeWidth={2.5}
+                        />
+                        {b}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              </GlassCard>
+            );
+          })}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/*                             PROGRAM & TIMELINE                             */
+/* -------------------------------------------------------------------------- */
+
+function Program() {
+  const [active, setActive] = useState(PHASES[0].id);
+  const phase = PHASES.find((p) => p.id === active);
+  const Icon = phase.icon;
+
+  return (
+    <section id="program" className="relative py-24 md:py-32">
+      <div className="mx-auto max-w-7xl px-6">
+        <div className="flex flex-col items-start justify-between gap-6 md:flex-row md:items-end">
+          <div className="max-w-2xl">
+            <SectionLabel>Program Structure</SectionLabel>
+            <h2 className="mt-5 text-balance text-3xl font-bold tracking-tight text-white md:text-5xl">
+              Two phases. One robot.{" "}
+              <span className="bg-gradient-to-r from-emerald-300 to-sky-300 bg-clip-text text-transparent">
+                Six hours a week.
+              </span>
+            </h2>
+          </div>
+          <div className="flex items-center gap-2 rounded-full border border-white/10 bg-white/[0.03] px-4 py-2 text-xs font-mono uppercase tracking-[0.18em] text-slate-300 backdrop-blur-md">
+            <Clock className="h-3.5 w-3.5 text-emerald-300" />
+            6 hr / week · 20 weeks total
+          </div>
+        </div>
+
+        {/* tab switcher */}
+        <div className="mt-12 inline-flex rounded-2xl border border-white/10 bg-white/[0.03] p-1.5 backdrop-blur-md">
+          {PHASES.map((p) => {
+            const isActive = active === p.id;
+            return (
+              <button
+                key={p.id}
+                onClick={() => setActive(p.id)}
+                className={`relative rounded-xl px-5 py-2.5 text-sm font-medium transition-all duration-300 ${
+                  isActive
+                    ? "text-slate-950"
+                    : "text-slate-300 hover:text-white"
+                }`}
+              >
+                {isActive && (
+                  <span className="absolute inset-0 rounded-xl bg-gradient-to-r from-emerald-300 to-sky-300 shadow-[0_0_20px_-4px_rgba(52,211,153,0.7)]" />
+                )}
+                <span className="relative flex items-center gap-2">
+                  <span className="font-mono text-[10px] uppercase tracking-[0.18em] opacity-70">
+                    Phase {p.id === "summer" ? "01" : "02"}
+                  </span>
+                  {p.title}
+                </span>
+              </button>
+            );
+          })}
+        </div>
+
+        {/* phase detail */}
+        <GlassCard className="mt-8 overflow-hidden p-0">
+          <div className="grid lg:grid-cols-[1.1fr_1fr]">
+            <div className="relative p-8 md:p-10">
+              <div className="flex items-center gap-3">
+                <div className="grid h-12 w-12 place-items-center rounded-xl bg-emerald-400/10 ring-1 ring-emerald-400/30">
+                  <Icon className="h-6 w-6 text-emerald-300" strokeWidth={1.8} />
+                </div>
+                <div>
+                  <div className="font-mono text-[10px] uppercase tracking-[0.18em] text-slate-400">
+                    {phase.cadence} · {phase.duration}
+                  </div>
+                  <h3 className="text-2xl font-semibold text-white">
+                    {phase.title}{" "}
+                    <span className="text-slate-400">— {phase.subtitle}</span>
+                  </h3>
+                </div>
+              </div>
+
+              <div className="mt-8">
+                <div className="text-xs font-mono uppercase tracking-[0.18em] text-emerald-300">
+                  End-of-phase milestone
+                </div>
+                <p className="mt-3 text-base leading-relaxed text-slate-200">
+                  {phase.milestone}
+                </p>
+              </div>
+
+              <div className="mt-8 grid gap-3 sm:grid-cols-3">
+                {phase.deliverables.map((d) => (
+                  <div
+                    key={d}
+                    className="rounded-xl border border-white/10 bg-white/[0.02] p-4"
+                  >
+                    <Sparkles className="h-4 w-4 text-emerald-300" />
+                    <div className="mt-2 text-sm leading-snug text-slate-200">{d}</div>
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            {/* visual timeline */}
+            <div className="relative border-t border-white/5 bg-gradient-to-br from-slate-900/50 to-slate-950/50 p-8 md:p-10 lg:border-l lg:border-t-0">
+              <div className="font-mono text-[10px] uppercase tracking-[0.18em] text-slate-400">
+                Weekly cadence
+              </div>
+              <div className="mt-5 space-y-3">
+                {PHASES.map((p) => {
+                  const PIcon = p.icon;
+                  const isActive = p.id === active;
+                  const weeks = p.id === "summer" ? 8 : 12;
+                  return (
+                    <div key={p.id}>
+                      <div className="mb-1.5 flex items-center justify-between text-xs">
+                        <span
+                          className={`flex items-center gap-1.5 font-mono uppercase tracking-[0.18em] ${
+                            isActive ? "text-emerald-300" : "text-slate-500"
+                          }`}
+                        >
+                          <PIcon className="h-3 w-3" />
+                          {p.title}
+                        </span>
+                        <span
+                          className={
+                            isActive ? "text-emerald-300" : "text-slate-500"
+                          }
+                        >
+                          {weeks} wk
+                        </span>
+                      </div>
+                      <div className="h-2 overflow-hidden rounded-full bg-white/5">
+                        <div
+                          className={`h-full rounded-full transition-all duration-700 ${
+                            isActive
+                              ? "bg-gradient-to-r from-emerald-300 to-sky-300 shadow-[0_0_18px_-2px_rgba(52,211,153,0.7)]"
+                              : "bg-white/10"
+                          }`}
+                          style={{
+                            width: `${(weeks / 20) * 100}%`,
+                          }}
+                        />
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+
+              <div className="mt-8 rounded-xl border border-white/10 bg-slate-950/40 p-5">
+                <div className="flex items-start gap-3">
+                  <Calendar className="mt-0.5 h-4 w-4 flex-shrink-0 text-sky-300" />
+                  <div>
+                    <div className="text-sm font-semibold text-white">Hybrid schedule</div>
+                    <p className="mt-1 text-sm leading-relaxed text-slate-300">
+                      In-person lab build sessions on weekends during summer, plus weeknight
+                      virtual office hours throughout the fall academy.
+                    </p>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </GlassCard>
+      </div>
+    </section>
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/*                              SYLLABUS ACCORDION                            */
+/* -------------------------------------------------------------------------- */
+
+function Syllabus() {
+  const [open, setOpen] = useState(0);
+
+  return (
+    <section id="syllabus" className="relative py-24 md:py-32">
+      <div className="mx-auto max-w-5xl px-6">
+        <div className="max-w-2xl">
+          <SectionLabel>High-Level Syllabus</SectionLabel>
+          <h2 className="mt-5 text-balance text-3xl font-bold tracking-tight text-white md:text-5xl">
+            20 weeks, mapped to{" "}
+            <span className="bg-gradient-to-r from-emerald-300 to-sky-300 bg-clip-text text-transparent">
+              real engineering deliverables.
+            </span>
+          </h2>
+          <p className="mt-5 text-base leading-relaxed text-slate-300">
+            Each module is taught lab-first: a short concept primer, then hands-on time on the
+            bench or in simulation, then a code review with your mentor.
+          </p>
+        </div>
+
+        <div className="mt-12 overflow-hidden rounded-2xl border border-white/10 bg-white/[0.02] backdrop-blur-md">
+          {SYLLABUS.map((row, i) => {
+            const Icon = row.icon;
+            const isOpen = open === i;
+            return (
+              <div
+                key={row.weeks}
+                className={`border-b border-white/5 last:border-b-0 ${
+                  isOpen ? "bg-white/[0.02]" : ""
+                }`}
+              >
+                <button
+                  onClick={() => setOpen(isOpen ? -1 : i)}
+                  className="group flex w-full items-center gap-4 px-5 py-5 text-left transition-colors hover:bg-white/[0.03] md:px-7"
+                >
+                  <div
+                    className={`grid h-10 w-10 flex-shrink-0 place-items-center rounded-lg ring-1 transition-all ${
+                      isOpen
+                        ? "bg-emerald-400/10 ring-emerald-400/40 text-emerald-300"
+                        : "bg-white/5 ring-white/10 text-slate-300 group-hover:text-emerald-300"
+                    }`}
+                  >
+                    <Icon className="h-5 w-5" strokeWidth={1.8} />
+                  </div>
+
+                  <div className="hidden w-28 flex-shrink-0 font-mono text-[11px] uppercase tracking-[0.18em] text-slate-400 sm:block">
+                    {row.weeks}
+                  </div>
+
+                  <div className="min-w-0 flex-1">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <span className="text-base font-semibold text-white md:text-lg">
+                        {row.title}
+                      </span>
+                      {row.milestone && (
+                        <span className="inline-flex items-center gap-1 rounded-full border border-emerald-400/30 bg-emerald-400/10 px-2 py-0.5 font-mono text-[9px] uppercase tracking-[0.16em] text-emerald-200">
+                          <Award className="h-2.5 w-2.5" /> Milestone
+                        </span>
+                      )}
+                      <span className="rounded-full border border-white/10 px-2 py-0.5 font-mono text-[9px] uppercase tracking-[0.16em] text-slate-400">
+                        {row.phase}
+                      </span>
+                    </div>
+                    <div className="mt-1 font-mono text-[10px] uppercase tracking-[0.18em] text-slate-500 sm:hidden">
+                      {row.weeks}
+                    </div>
+                  </div>
+
+                  <ChevronDown
+                    className={`h-5 w-5 flex-shrink-0 text-slate-400 transition-transform duration-300 ${
+                      isOpen ? "rotate-180 text-emerald-300" : ""
+                    }`}
+                  />
+                </button>
+
+                <div
+                  className={`grid overflow-hidden transition-all duration-300 ease-out ${
+                    isOpen ? "grid-rows-[1fr] opacity-100" : "grid-rows-[0fr] opacity-0"
+                  }`}
+                >
+                  <div className="min-h-0">
+                    <div className="px-5 pb-6 pl-[68px] text-sm leading-relaxed text-slate-300 md:px-7 md:pl-[180px]">
+                      {row.blurb}
+                    </div>
+                  </div>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/*                            MENTORSHIP ADVANTAGE                            */
+/* -------------------------------------------------------------------------- */
+
+function Mentorship() {
+  return (
+    <section id="mentorship" className="relative py-24 md:py-32">
+      <div className="mx-auto max-w-7xl px-6">
+        <GlassCard className="overflow-hidden p-0">
+          <div className="grid lg:grid-cols-[1.2fr_1fr]">
+            <div className="relative p-8 md:p-12">
+              <SectionLabel>The Mentorship Advantage</SectionLabel>
+              <h2 className="mt-5 text-balance text-3xl font-bold tracking-tight text-white md:text-5xl">
+                You're not following a tutorial.{" "}
+                <span className="bg-gradient-to-r from-emerald-300 to-sky-300 bg-clip-text text-transparent">
+                  You're shipping research.
+                </span>
+              </h2>
+              <p className="mt-5 max-w-xl text-base leading-relaxed text-slate-300">
+                Every cohort student builds against the same platform Stanford's research team
+                publishes on. Your code, sims, and hardware get reviewed by the people who wrote
+                the paper.
+              </p>
+
+              <div className="mt-10 space-y-5">
+                {[
+                  {
+                    icon: ShieldCheck,
+                    title: "Direct technical consultation",
+                    body:
+                      "The 1st and 2nd authors of the original ToddlerBot paper serve as Technical Consultants — reviewing student code, simulation designs, and hardware builds.",
+                  },
+                  {
+                    icon: Users,
+                    title: "Genboo engineers as lead mentors",
+                    body:
+                      "Working roboticists run weekly labs, code reviews, and 1:1s. Maximum 5 students per mentor so feedback is dense and personal.",
+                  },
+                  {
+                    icon: Github,
+                    title: "Real open-source contributions",
+                    body:
+                      "Your improvements to drivers, sim tooling, and policies can land upstream in the ToddlerBot repository — a portfolio piece that compounds.",
+                  },
+                ].map((item) => {
+                  const Icon = item.icon;
+                  return (
+                    <div key={item.title} className="flex gap-4">
+                      <div className="grid h-10 w-10 flex-shrink-0 place-items-center rounded-lg bg-emerald-400/10 ring-1 ring-emerald-400/30">
+                        <Icon className="h-5 w-5 text-emerald-300" strokeWidth={1.8} />
+                      </div>
+                      <div>
+                        <div className="font-semibold text-white">{item.title}</div>
+                        <p className="mt-1 text-sm leading-relaxed text-slate-300">
+                          {item.body}
+                        </p>
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+
+            <div className="relative overflow-hidden border-t border-white/5 bg-gradient-to-br from-slate-900/40 to-slate-950/60 p-8 md:p-12 lg:border-l lg:border-t-0">
+              <div className="pointer-events-none absolute -right-20 -top-20 h-72 w-72 rounded-full bg-emerald-500/20 blur-[100px]" />
+              <div className="pointer-events-none absolute -left-10 bottom-0 h-60 w-60 rounded-full bg-sky-500/15 blur-[100px]" />
+
+              <div className="relative">
+                <div className="font-mono text-[10px] uppercase tracking-[0.18em] text-slate-400">
+                  Source platform
+                </div>
+                <a
+                  href="https://toddlerbot.github.io/"
+                  target="_blank"
+                  rel="noreferrer"
+                  className="mt-3 inline-flex items-center gap-2 text-2xl font-semibold text-white hover:text-emerald-300"
+                >
+                  ToddlerBot
+                  <ArrowRight className="h-5 w-5 -rotate-45" />
+                </a>
+                <p className="mt-2 text-sm text-slate-400">
+                  Stanford-published open-source humanoid research platform.
+                </p>
+
+                <div className="mt-8 space-y-3">
+                  {[
+                    { label: "Active DoFs", value: "30" },
+                    { label: "Compute", value: "Jetson Orin NX" },
+                    { label: "Perception", value: "Stereo fisheye" },
+                    { label: "Sim", value: "MuJoCo + MJX" },
+                    { label: "Policy", value: "RL omnidirectional" },
+                  ].map((s) => (
+                    <div
+                      key={s.label}
+                      className="flex items-center justify-between rounded-lg border border-white/10 bg-white/[0.02] px-4 py-3"
+                    >
+                      <span className="font-mono text-[10px] uppercase tracking-[0.18em] text-slate-400">
+                        {s.label}
+                      </span>
+                      <span className="text-sm font-medium text-white">{s.value}</span>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            </div>
+          </div>
+        </GlassCard>
+      </div>
+    </section>
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/*                             APPLICATION / CTA                              */
+/* -------------------------------------------------------------------------- */
+
+function ApplyCTA() {
+  const [submitted, setSubmitted] = useState(false);
+  const [form, setForm] = useState({ name: "", email: "", school: "", note: "" });
+
+  const onChange = (e) => setForm({ ...form, [e.target.name]: e.target.value });
+  const onSubmit = (e) => {
+    e.preventDefault();
+    setSubmitted(true);
+  };
+
+  return (
+    <section id="apply" className="relative py-24 md:py-32">
+      <div className="mx-auto max-w-6xl px-6">
+        <div className="relative overflow-hidden rounded-3xl border border-white/10 bg-white/[0.03] backdrop-blur-xl">
+          {/* glow background */}
+          <div className="pointer-events-none absolute inset-0">
+            <div className="absolute -left-32 -top-32 h-96 w-96 rounded-full bg-emerald-500/25 blur-[140px]" />
+            <div className="absolute -right-32 -bottom-32 h-96 w-96 rounded-full bg-sky-500/20 blur-[140px]" />
+            <div
+              className="absolute inset-0 opacity-[0.12]"
+              style={{
+                backgroundImage:
+                  "radial-gradient(circle at 1px 1px, rgba(255,255,255,0.5) 1px, transparent 0)",
+                backgroundSize: "26px 26px",
+              }}
+            />
+          </div>
+
+          <div className="relative grid gap-10 p-8 md:p-12 lg:grid-cols-[1.05fr_1fr] lg:gap-14">
+            <div>
+              <SectionLabel>Apply · Cohort 01</SectionLabel>
+              <h2 className="mt-5 text-balance text-3xl font-bold tracking-tight text-white md:text-5xl">
+                Seats are{" "}
+                <span className="bg-gradient-to-r from-emerald-300 to-sky-300 bg-clip-text text-transparent">
+                  strictly limited.
+                </span>
+              </h2>
+              <p className="mt-5 max-w-xl text-base leading-relaxed text-slate-300">
+                Due to hardware complexity and lab space constraints, this cohort is highly
+                selective. Ideal candidates have prior exposure to programming{" "}
+                <span className="font-mono text-emerald-200">(Python / C++)</span> or competitive
+                robotics <span className="font-mono text-emerald-200">(VEX / FRC)</span> — but
+                passion and problem-solving drive are prioritized over credentials.
+              </p>
+
+              <div className="mt-8 space-y-3">
+                {[
+                  "Open to current high school students (grades 9–12).",
+                  "Rolling admissions — earlier applicants get priority lab access.",
+                  "Need-based scholarships available for hardware kit costs.",
+                ].map((n) => (
+                  <div key={n} className="flex items-start gap-3 text-sm text-slate-300">
+                    <Check className="mt-0.5 h-4 w-4 flex-shrink-0 text-emerald-300" strokeWidth={2.5} />
+                    {n}
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            {/* form card */}
+            <div className="rounded-2xl border border-white/10 bg-slate-950/60 p-7 backdrop-blur-xl">
+              {!submitted ? (
+                <form onSubmit={onSubmit} className="space-y-4">
+                  <div className="font-mono text-[10px] uppercase tracking-[0.18em] text-emerald-300">
+                    Express interest
+                  </div>
+                  <h3 className="text-xl font-semibold text-white">
+                    Start your application
+                  </h3>
+
+                  <div className="space-y-3 pt-2">
+                    {[
+                      { name: "name", placeholder: "Full name", type: "text" },
+                      { name: "email", placeholder: "Email", type: "email" },
+                      { name: "school", placeholder: "School & grade", type: "text" },
+                    ].map((f) => (
+                      <input
+                        key={f.name}
+                        type={f.type}
+                        name={f.name}
+                        required
+                        value={form[f.name]}
+                        onChange={onChange}
+                        placeholder={f.placeholder}
+                        className="w-full rounded-xl border border-white/10 bg-white/[0.03] px-4 py-3 text-sm text-white placeholder:text-slate-500 transition-colors focus:border-emerald-400/50 focus:outline-none focus:ring-2 focus:ring-emerald-400/20"
+                      />
+                    ))}
+                    <textarea
+                      name="note"
+                      rows={3}
+                      value={form.note}
+                      onChange={onChange}
+                      placeholder="A robotics project, repo, or build you're proud of (optional)"
+                      className="w-full resize-none rounded-xl border border-white/10 bg-white/[0.03] px-4 py-3 text-sm text-white placeholder:text-slate-500 transition-colors focus:border-emerald-400/50 focus:outline-none focus:ring-2 focus:ring-emerald-400/20"
+                    />
+                  </div>
+
+                  <button
+                    type="submit"
+                    className="group relative mt-2 inline-flex w-full items-center justify-center gap-2 overflow-hidden rounded-xl px-6 py-3.5 text-sm font-semibold text-slate-950 transition-all"
+                  >
+                    <span className="absolute inset-0 bg-gradient-to-r from-emerald-400 via-emerald-300 to-sky-400" />
+                    <span className="absolute inset-0 bg-gradient-to-r from-emerald-400 via-emerald-300 to-sky-400 opacity-70 blur-xl transition-opacity group-hover:opacity-100" />
+                    <span className="relative flex items-center gap-2">
+                      Submit Application
+                      <ArrowRight className="h-4 w-4 transition-transform group-hover:translate-x-0.5" />
+                    </span>
+                  </button>
+
+                  <p className="pt-1 text-center text-[11px] text-slate-500">
+                    We'll follow up within 5 business days with next steps.
+                  </p>
+                </form>
+              ) : (
+                <div className="flex flex-col items-center py-10 text-center">
+                  <div className="grid h-14 w-14 place-items-center rounded-full bg-emerald-400/15 ring-1 ring-emerald-400/40">
+                    <Check className="h-7 w-7 text-emerald-300" strokeWidth={2.5} />
+                  </div>
+                  <h3 className="mt-5 text-xl font-semibold text-white">
+                    Application received
+                  </h3>
+                  <p className="mt-2 max-w-xs text-sm text-slate-300">
+                    Thanks, {form.name?.split(" ")[0] || "future roboticist"}. We'll reach out
+                    within 5 business days.
+                  </p>
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/*                                   FOOTER                                   */
+/* -------------------------------------------------------------------------- */
+
+function Footer() {
+  return (
+    <footer className="relative border-t border-white/5 bg-slate-950/60 py-10 backdrop-blur-xl">
+      <div className="mx-auto flex max-w-7xl flex-col items-center justify-between gap-4 px-6 md:flex-row">
+        <div className="flex items-center gap-2.5">
+          <span className="grid h-8 w-8 place-items-center rounded-lg bg-gradient-to-br from-emerald-400 to-sky-500 text-slate-950">
+            <Bot className="h-4 w-4" strokeWidth={2.4} />
+          </span>
+          <div className="leading-tight">
+            <div className="text-sm font-semibold text-white">humanoid.genboo.com</div>
+            <div className="font-mono text-[10px] uppercase tracking-[0.18em] text-slate-400">
+              © 2026 Genboo LLC
+            </div>
+          </div>
+        </div>
+
+        <div className="flex items-center gap-5 text-xs text-slate-400">
+          <a href="mailto:humanoid@genboo.com" className="inline-flex items-center gap-1.5 hover:text-emerald-300">
+            <Mail className="h-3.5 w-3.5" /> humanoid@genboo.com
+          </a>
+          <span className="inline-flex items-center gap-1.5">
+            <MapPin className="h-3.5 w-3.5" /> Bay Area, CA
+          </span>
+          <a
+            href="https://toddlerbot.github.io/"
+            target="_blank"
+            rel="noreferrer"
+            className="inline-flex items-center gap-1.5 hover:text-emerald-300"
+          >
+            <Github className="h-3.5 w-3.5" /> ToddlerBot
+          </a>
+        </div>
+      </div>
+    </footer>
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/*                                   PAGE                                     */
+/* -------------------------------------------------------------------------- */
+
+export default function HumanoidCohort() {
+  return (
+    <div className="relative min-h-screen overflow-x-hidden bg-slate-950 font-sans text-white antialiased selection:bg-emerald-400/30 selection:text-white">
+      {/* global ambient backdrop */}
+      <div className="pointer-events-none fixed inset-0 -z-10">
+        <div className="absolute inset-0 bg-[radial-gradient(ellipse_1200px_800px_at_15%_-10%,rgba(16,185,129,0.10),transparent_60%)]" />
+        <div className="absolute inset-0 bg-[radial-gradient(ellipse_1000px_700px_at_85%_10%,rgba(56,189,248,0.08),transparent_65%)]" />
+      </div>
+
+      <Nav />
+      <main>
+        <Hero />
+        <Platform />
+        <Program />
+        <Syllabus />
+        <Mentorship />
+        <ApplyCTA />
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/humanoid/favicon.svg
+++ b/humanoid/favicon.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="64" y2="64" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#34d399"/>
+      <stop offset="1" stop-color="#38bdf8"/>
+    </linearGradient>
+    <linearGradient id="gloss" x1="0" y1="0" x2="0" y2="64" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#ffffff" stop-opacity="0.25"/>
+      <stop offset="0.55" stop-color="#ffffff" stop-opacity="0"/>
+    </linearGradient>
+  </defs>
+  <rect width="64" height="64" rx="14" ry="14" fill="url(#g)"/>
+  <rect width="64" height="64" rx="14" ry="14" fill="url(#gloss)"/>
+  <g fill="#0b1220" font-family="'Noto Sans SC','PingFang SC','Hiragino Sans GB','Microsoft YaHei','Source Han Sans SC',system-ui,sans-serif" font-weight="900" text-anchor="middle">
+    <text x="32" y="29" font-size="26">Û</text>
+    <text x="32" y="55" font-size="26">e</text>
+  </g>
+</svg>

--- a/humanoid/index.html
+++ b/humanoid/index.html
@@ -1,0 +1,989 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-RZVF6K9DJ5"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-RZVF6K9DJ5');
+    </script>
+
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Humanoid Cohort 01 — Genboo Robotics × ToddlerBot</title>
+    <meta name="description" content="An elite 20-week cohort for high school students to construct, simulate, and train ToddlerBot — the open-source ML-compatible humanoid platform. Mentored by Genboo engineers with technical consultation from the paper's original authors." />
+    <link rel="icon" type="image/svg+xml" href="favicon.svg" />
+    <link rel="alternate icon" type="image/x-icon" href="../genboo_favicon_padded.ico" />
+    <link rel="apple-touch-icon" href="favicon.svg" />
+    <meta name="theme-color" content="#34d399" />
+
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600&family=Noto+Sans+SC:wght@500;700;900&display=swap" rel="stylesheet" />
+
+    <!-- Tailwind CDN -->
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script>
+      tailwind.config = {
+        theme: {
+          extend: {
+            fontFamily: {
+              sans: ['Inter', 'system-ui', 'sans-serif'],
+              mono: ['JetBrains Mono', 'ui-monospace', 'monospace'],
+            },
+          },
+        },
+      };
+    </script>
+
+    <style>
+      html { scroll-behavior: smooth; }
+      body { font-family: 'Inter', system-ui, sans-serif; }
+      .font-mono { font-family: 'JetBrains Mono', ui-monospace, monospace; }
+      .font-cjk { font-family: 'Noto Sans SC', 'PingFang SC', 'Microsoft YaHei', system-ui, sans-serif; }
+
+      /* 进步 logo mark */
+      .logo-mark {
+        position: relative;
+        background-image: linear-gradient(135deg, #34d399 0%, #38bdf8 100%);
+        box-shadow: 0 0 24px -4px rgba(52, 211, 153, 0.6), inset 0 1px 0 0 rgba(255,255,255,0.25);
+      }
+      .logo-mark::after {
+        content: "";
+        position: absolute; inset: 0;
+        border-radius: inherit;
+        background: linear-gradient(135deg, rgba(255,255,255,0.18), rgba(255,255,255,0) 55%);
+        pointer-events: none;
+      }
+      .logo-cjk {
+        font-family: 'Noto Sans SC', 'PingFang SC', 'Microsoft YaHei', system-ui, sans-serif;
+        font-weight: 900;
+        color: #0b1220;
+        line-height: 0.85;
+        letter-spacing: -0.02em;
+        text-align: center;
+        display: flex; flex-direction: column; align-items: center; justify-content: center;
+      }
+
+      /* Accordion smooth open/close via grid-rows trick */
+      .acc-panel { display: grid; grid-template-rows: 0fr; transition: grid-template-rows 300ms ease, opacity 300ms ease; opacity: 0; }
+      .acc-panel > div { min-height: 0; }
+      .acc-item.open .acc-panel { grid-template-rows: 1fr; opacity: 1; }
+      .acc-item.open .acc-chevron { transform: rotate(180deg); color: #6ee7b7; }
+      .acc-item.open .acc-icon-wrap { background-color: rgba(52, 211, 153, 0.10); box-shadow: inset 0 0 0 1px rgba(52, 211, 153, 0.40); color: #6ee7b7; }
+
+      /* Pulsing dot */
+      @keyframes pulse-ring { 0% { transform: scale(.85); opacity: .75; } 80%, 100% { transform: scale(1.6); opacity: 0; } }
+      .pulse-dot::before { content: ""; position: absolute; inset: 0; border-radius: 9999px; background: #34d399; animation: pulse-ring 1.6s cubic-bezier(0,0,.2,1) infinite; }
+
+      /* Glow CTA */
+      .glow-cta::before {
+        content: ""; position: absolute; inset: 0; border-radius: 0.75rem;
+        background: linear-gradient(to right, #34d399, #6ee7b7, #38bdf8);
+        opacity: .7; filter: blur(22px); transition: opacity .3s ease;
+        z-index: 0;
+      }
+      .glow-cta:hover::before { opacity: 1; }
+      .glow-cta > .glow-cta-bg { position: absolute; inset: 0; border-radius: 0.75rem; background: linear-gradient(to right, #34d399, #6ee7b7, #38bdf8); z-index: 0; }
+      .glow-cta > .glow-cta-inner { position: relative; z-index: 1; }
+
+      /* Selection color */
+      ::selection { background: rgba(52, 211, 153, 0.35); color: #fff; }
+
+      /* Phase tab active pill */
+      .phase-btn.active { color: #020617; }
+      .phase-btn.active .phase-pill { opacity: 1; }
+      .phase-btn .phase-pill { position: absolute; inset: 0; border-radius: 0.75rem; background: linear-gradient(to right, #6ee7b7, #7dd3fc); box-shadow: 0 0 20px -4px rgba(52,211,153,0.7); opacity: 0; transition: opacity .25s ease; z-index: 0; }
+      .phase-btn > .phase-content { position: relative; z-index: 1; }
+
+      /* Phase content show/hide */
+      .phase-panel { display: none; }
+      .phase-panel.active { display: grid; }
+
+      /* Dot grid mask overlay */
+      .dot-grid {
+        background-image: radial-gradient(circle at 1px 1px, rgba(255,255,255,0.35) 1px, transparent 0);
+        background-size: 28px 28px;
+        -webkit-mask-image: radial-gradient(ellipse 80% 60% at 50% 30%, #000 40%, transparent 100%);
+                mask-image: radial-gradient(ellipse 80% 60% at 50% 30%, #000 40%, transparent 100%);
+      }
+
+      /* Card hover lift */
+      .card-hover { transition: transform .3s ease, border-color .3s ease, background-color .3s ease; }
+      .card-hover:hover { transform: translateY(-4px); }
+    </style>
+  </head>
+
+  <body class="relative min-h-screen overflow-x-hidden bg-slate-950 text-white antialiased">
+
+    <!-- Global ambient backdrop -->
+    <div class="pointer-events-none fixed inset-0 -z-10">
+      <div class="absolute inset-0" style="background: radial-gradient(ellipse 1200px 800px at 15% -10%, rgba(16,185,129,0.10), transparent 60%);"></div>
+      <div class="absolute inset-0" style="background: radial-gradient(ellipse 1000px 700px at 85% 10%, rgba(56,189,248,0.08), transparent 65%);"></div>
+    </div>
+
+    <!-- ================================ NAV ================================ -->
+    <header class="fixed inset-x-0 top-0 z-50 border-b border-white/5 bg-slate-950/60 backdrop-blur-xl">
+      <div class="mx-auto flex max-w-7xl items-center justify-between px-6 py-4">
+        <a href="#" class="flex items-center gap-2.5">
+          <span class="logo-mark relative grid h-9 w-9 place-items-center rounded-lg">
+            <span class="logo-cjk relative z-10 text-[12px]">
+              <span>进</span>
+              <span>步</span>
+            </span>
+          </span>
+          <div class="leading-tight">
+            <div class="text-sm font-semibold text-white">Genboo · <span class="font-cjk font-bold text-emerald-300">进步</span></div>
+            <div class="font-mono text-[10px] uppercase tracking-[0.18em] text-slate-400">Humanoid Cohort</div>
+          </div>
+        </a>
+
+        <nav class="hidden items-center gap-8 md:flex">
+          <a href="#platform" class="text-sm text-slate-300 transition-colors hover:text-emerald-300">Platform</a>
+          <a href="#program" class="text-sm text-slate-300 transition-colors hover:text-emerald-300">Program</a>
+          <a href="#syllabus" class="text-sm text-slate-300 transition-colors hover:text-emerald-300">Syllabus</a>
+          <a href="#mentorship" class="text-sm text-slate-300 transition-colors hover:text-emerald-300">Mentorship</a>
+        </nav>
+
+        <a href="#apply" class="glow-cta group relative hidden md:inline-flex items-center justify-center gap-2 rounded-xl px-5 py-2.5 text-sm font-semibold text-slate-950">
+          <span class="glow-cta-bg"></span>
+          <span class="glow-cta-inner flex items-center gap-2">Apply <i data-lucide="arrow-right" class="h-4 w-4"></i></span>
+        </a>
+      </div>
+    </header>
+
+    <main>
+      <!-- ================================ HERO =============================== -->
+      <section class="relative overflow-hidden pt-36 pb-24 md:pt-44 md:pb-32">
+        <div class="pointer-events-none absolute inset-0 -z-10">
+          <div class="absolute -top-32 left-1/2 h-[36rem] w-[36rem] -translate-x-1/2 rounded-full bg-emerald-500/20 blur-[140px]"></div>
+          <div class="absolute right-[-10rem] top-40 h-[28rem] w-[28rem] rounded-full bg-sky-500/15 blur-[140px]"></div>
+          <div class="absolute left-[-10rem] bottom-[-10rem] h-[28rem] w-[28rem] rounded-full bg-emerald-400/10 blur-[140px]"></div>
+        </div>
+
+        <div class="dot-grid pointer-events-none absolute inset-0 -z-10 opacity-[0.18]"></div>
+
+        <div class="mx-auto max-w-7xl px-6">
+          <div class="flex flex-col items-center text-center">
+
+            <div class="mb-7 inline-flex items-center gap-2 rounded-full border border-emerald-400/30 bg-emerald-400/5 px-4 py-1.5 text-xs font-mono uppercase tracking-[0.18em] text-emerald-200">
+              <span class="pulse-dot relative inline-block h-2 w-2 rounded-full bg-emerald-400"></span>
+              Cohort 01 · Now Accepting Applications
+            </div>
+
+            <h1 class="max-w-5xl bg-gradient-to-br from-white via-white to-slate-400 bg-clip-text text-4xl font-bold leading-[1.05] tracking-tight text-transparent sm:text-5xl md:text-6xl lg:text-7xl">
+              Build a Humanoid Robot From Scratch.
+              <br class="hidden md:block" />
+              <span class="bg-gradient-to-r from-emerald-300 via-emerald-200 to-sky-300 bg-clip-text text-transparent">Master ME, EE, and AI.</span>
+            </h1>
+
+            <p class="mt-7 max-w-3xl text-base leading-relaxed text-slate-300 md:text-lg">
+              An elite <span class="font-semibold text-white">20-week cohort</span> for high school students to construct, simulate, and train
+              <span class="font-semibold text-emerald-300">ToddlerBot</span> — the open-source, ML-compatible humanoid platform. Mentored by Genboo engineers with direct technical consultation from the paper's original 1st and 2nd authors.
+            </p>
+
+            <div class="mt-10 flex flex-col items-center gap-3 sm:flex-row sm:gap-4">
+              <a href="#apply" class="glow-cta group relative inline-flex items-center justify-center gap-2 rounded-xl px-6 py-3.5 text-sm font-semibold text-slate-950">
+                <span class="glow-cta-bg"></span>
+                <span class="glow-cta-inner flex items-center gap-2">Apply for the Cohort <i data-lucide="arrow-right" class="h-4 w-4 transition-transform group-hover:translate-x-0.5"></i></span>
+              </a>
+              <a href="#syllabus" class="group inline-flex items-center justify-center gap-2 rounded-xl border border-white/15 bg-white/[0.03] px-6 py-3.5 text-sm font-semibold text-white backdrop-blur-md transition-all duration-300 hover:border-emerald-400/40 hover:bg-white/[0.06] hover:text-emerald-200">
+                <i data-lucide="scroll-text" class="h-4 w-4"></i>
+                View Syllabus
+                <i data-lucide="arrow-right" class="h-4 w-4 opacity-60 transition-all group-hover:translate-x-0.5 group-hover:opacity-100"></i>
+              </a>
+            </div>
+
+            <div class="mt-14 grid w-full max-w-4xl grid-cols-2 gap-px overflow-hidden rounded-2xl border border-white/10 bg-white/[0.02] sm:grid-cols-4">
+              <div class="bg-slate-950/60 px-6 py-5 text-center backdrop-blur-md">
+                <div class="bg-gradient-to-b from-white to-slate-400 bg-clip-text text-3xl font-bold text-transparent">20</div>
+                <div class="mt-1 font-mono text-[10px] uppercase tracking-[0.18em] text-slate-400">Weeks</div>
+              </div>
+              <div class="bg-slate-950/60 px-6 py-5 text-center backdrop-blur-md">
+                <div class="bg-gradient-to-b from-white to-slate-400 bg-clip-text text-3xl font-bold text-transparent">30</div>
+                <div class="mt-1 font-mono text-[10px] uppercase tracking-[0.18em] text-slate-400">Active DoFs</div>
+              </div>
+              <div class="bg-slate-950/60 px-6 py-5 text-center backdrop-blur-md">
+                <div class="bg-gradient-to-b from-white to-slate-400 bg-clip-text text-3xl font-bold text-transparent">6 hr</div>
+                <div class="mt-1 font-mono text-[10px] uppercase tracking-[0.18em] text-slate-400">Per Week</div>
+              </div>
+              <div class="bg-slate-950/60 px-6 py-5 text-center backdrop-blur-md">
+                <div class="bg-gradient-to-b from-white to-slate-400 bg-clip-text text-3xl font-bold text-transparent">1:5</div>
+                <div class="mt-1 font-mono text-[10px] uppercase tracking-[0.18em] text-slate-400">Mentor Ratio</div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- =========================== SHOWCASE ============================ -->
+      <section id="showcase" class="relative py-16 md:py-24">
+        <div class="mx-auto max-w-7xl px-6">
+          <div class="grid items-center gap-10 lg:grid-cols-[1.35fr_1fr] lg:gap-14">
+
+            <!-- Video frame -->
+            <div class="relative">
+              <!-- ambient glow -->
+              <div class="pointer-events-none absolute -inset-6 -z-10 rounded-[2rem] bg-gradient-to-br from-emerald-500/25 via-emerald-400/10 to-sky-500/25 blur-2xl"></div>
+
+              <div class="group relative overflow-hidden rounded-2xl border border-white/10 bg-slate-950/60 shadow-[0_30px_80px_-20px_rgba(16,185,129,0.35)] backdrop-blur-xl">
+                <video
+                  class="block aspect-video w-full object-cover"
+                  src="../assets/videos/push_cart.mp4"
+                  autoplay
+                  muted
+                  loop
+                  playsinline
+                  preload="metadata"
+                  poster=""
+                ></video>
+
+                <!-- top-left badge -->
+                <div class="pointer-events-none absolute left-4 top-4 inline-flex items-center gap-2 rounded-full border border-emerald-400/30 bg-slate-950/70 px-3 py-1 text-[10px] font-mono uppercase tracking-[0.18em] text-emerald-200 backdrop-blur-md">
+                  <span class="pulse-dot relative inline-block h-1.5 w-1.5 rounded-full bg-emerald-400"></span>
+                  Live · ToddlerBot
+                </div>
+
+                <!-- bottom caption -->
+                <div class="pointer-events-none absolute inset-x-0 bottom-0 flex items-end justify-between gap-4 bg-gradient-to-t from-slate-950/90 via-slate-950/40 to-transparent p-4 md:p-5">
+                  <div>
+                    <div class="font-mono text-[10px] uppercase tracking-[0.18em] text-emerald-300">Capstone demo</div>
+                    <div class="mt-1 text-sm font-semibold text-white md:text-base">Whole-body manipulation: pushing a loaded cart</div>
+                  </div>
+                  <div class="hidden items-center gap-1.5 rounded-full border border-white/15 bg-white/[0.05] px-2.5 py-1 font-mono text-[10px] uppercase tracking-[0.18em] text-slate-200 backdrop-blur-md sm:inline-flex">
+                    <i data-lucide="play" class="h-3 w-3 text-emerald-300"></i>
+                    Auto
+                  </div>
+                </div>
+              </div>
+
+              <!-- bottom strip stats -->
+              <div class="mt-4 grid grid-cols-3 gap-px overflow-hidden rounded-xl border border-white/10 bg-white/[0.02]">
+                <div class="bg-slate-950/60 px-4 py-3 text-center">
+                  <div class="font-mono text-[10px] uppercase tracking-[0.18em] text-slate-400">Locomotion</div>
+                  <div class="mt-1 text-sm font-semibold text-white">RL · MJX trained</div>
+                </div>
+                <div class="bg-slate-950/60 px-4 py-3 text-center">
+                  <div class="font-mono text-[10px] uppercase tracking-[0.18em] text-slate-400">Perception</div>
+                  <div class="mt-1 text-sm font-semibold text-white">Stereo fisheye</div>
+                </div>
+                <div class="bg-slate-950/60 px-4 py-3 text-center">
+                  <div class="font-mono text-[10px] uppercase tracking-[0.18em] text-slate-400">Transfer</div>
+                  <div class="mt-1 text-sm font-semibold text-white">Sim → Real</div>
+                </div>
+              </div>
+            </div>
+
+            <!-- Copy -->
+            <div>
+              <div class="inline-flex items-center gap-2 text-xs font-mono uppercase tracking-[0.2em] text-emerald-300/90">
+                <span class="h-1.5 w-1.5 rounded-full bg-emerald-400 shadow-[0_0_12px_2px_rgba(52,211,153,0.7)]"></span>
+                See it in Action
+              </div>
+              <h2 class="mt-5 text-3xl font-bold tracking-tight text-white md:text-4xl lg:text-5xl">
+                This is what <span class="bg-gradient-to-r from-emerald-300 to-sky-300 bg-clip-text text-transparent">your robot</span> will do.
+              </h2>
+              <p class="mt-5 text-base leading-relaxed text-slate-300">
+                Whole-body coordination. Balanced contact forces. A learned policy transferring cleanly from simulation to the real chassis — pushing a loaded cart across the lab floor. That's the end state we engineer toward together.
+              </p>
+
+              <ul class="mt-7 space-y-3.5">
+                <li class="flex items-start gap-3 text-sm text-slate-200">
+                  <i data-lucide="check" class="mt-0.5 h-4 w-4 flex-shrink-0 text-emerald-300" stroke-width="2.5"></i>
+                  Train an <span class="font-semibold text-white">RL walking policy</span> in MJX, then deploy it onto the robot you built.
+                </li>
+                <li class="flex items-start gap-3 text-sm text-slate-200">
+                  <i data-lucide="check" class="mt-0.5 h-4 w-4 flex-shrink-0 text-emerald-300" stroke-width="2.5"></i>
+                  Calibrate contact dynamics so the robot can <span class="font-semibold text-white">apply real force to the world</span>.
+                </li>
+                <li class="flex items-start gap-3 text-sm text-slate-200">
+                  <i data-lucide="check" class="mt-0.5 h-4 w-4 flex-shrink-0 text-emerald-300" stroke-width="2.5"></i>
+                  Ship a portfolio-grade <span class="font-semibold text-white">sim-to-real</span> demo by the end of the cohort.
+                </li>
+              </ul>
+
+              <div class="mt-8 flex flex-wrap items-center gap-3">
+                <a href="#program" class="group inline-flex items-center gap-2 rounded-xl border border-white/15 bg-white/[0.03] px-4 py-2.5 text-sm font-semibold text-white backdrop-blur-md transition-all duration-300 hover:border-emerald-400/40 hover:bg-white/[0.06] hover:text-emerald-200">
+                  How we get there
+                  <i data-lucide="arrow-right" class="h-4 w-4 opacity-70 transition-transform group-hover:translate-x-0.5"></i>
+                </a>
+                <a href="https://toddlerbot.github.io/" target="_blank" rel="noreferrer" class="group inline-flex items-center gap-2 rounded-xl border border-white/10 bg-transparent px-4 py-2.5 text-sm font-medium text-slate-300 transition-all duration-300 hover:border-white/20 hover:text-white">
+                  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="h-4 w-4" aria-hidden="true">
+                    <path d="M12 .5C5.73.5.67 5.57.67 11.85c0 5.02 3.24 9.27 7.74 10.77.57.11.78-.25.78-.55v-2.13c-3.15.69-3.82-1.34-3.82-1.34-.51-1.31-1.26-1.66-1.26-1.66-1.03-.7.08-.69.08-.69 1.14.08 1.74 1.17 1.74 1.17 1.01 1.74 2.66 1.24 3.31.95.1-.74.4-1.24.72-1.53-2.51-.29-5.16-1.27-5.16-5.65 0-1.25.45-2.27 1.17-3.08-.12-.3-.51-1.46.11-3.05 0 0 .97-.31 3.18 1.18a11 11 0 0 1 2.9-.39c.98 0 1.97.13 2.9.39 2.2-1.49 3.17-1.18 3.17-1.18.63 1.59.23 2.75.11 3.05.73.81 1.17 1.83 1.17 3.08 0 4.39-2.66 5.36-5.18 5.64.41.36.78 1.06.78 2.13v3.16c0 .31.21.67.79.55 4.49-1.5 7.73-5.75 7.73-10.77C23.33 5.57 18.27.5 12 .5z"/>
+                  </svg>
+                  Original research
+                </a>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- =========================== PLATFORM ============================ -->
+      <section id="platform" class="relative py-24 md:py-32">
+        <div class="mx-auto max-w-7xl px-6">
+          <div class="mx-auto max-w-3xl text-center">
+            <div class="inline-flex items-center gap-2 text-xs font-mono uppercase tracking-[0.2em] text-emerald-300/90">
+              <span class="h-1.5 w-1.5 rounded-full bg-emerald-400 shadow-[0_0_12px_2px_rgba(52,211,153,0.7)]"></span>
+              The Platform
+            </div>
+            <h2 class="mt-5 text-3xl font-bold tracking-tight text-white md:text-5xl">
+              A research-grade humanoid, <span class="bg-gradient-to-r from-emerald-300 to-sky-300 bg-clip-text text-transparent">not a toy kit.</span>
+            </h2>
+            <p class="mt-5 text-base leading-relaxed text-slate-300 md:text-lg">
+              ToddlerBot is the Stanford-published, open-source humanoid platform you'll build, wire, and teach to walk. Every component is portfolio-grade.
+            </p>
+          </div>
+
+          <div class="mt-16 grid gap-6 lg:grid-cols-3">
+            <!-- ME -->
+            <div class="card-hover relative rounded-2xl border border-white/10 bg-white/[0.03] p-7 backdrop-blur-xl hover:border-white/20">
+              <div class="flex items-center justify-between">
+                <div class="grid h-12 w-12 place-items-center rounded-xl bg-white/5 ring-1 ring-emerald-400/30">
+                  <i data-lucide="cog" class="h-6 w-6 text-emerald-300" stroke-width="1.8"></i>
+                </div>
+                <span class="font-mono text-[10px] uppercase tracking-[0.18em] text-slate-400">ME</span>
+              </div>
+              <div class="mt-7">
+                <div class="text-xs font-mono uppercase tracking-[0.18em] text-slate-400">Mechanical Engineering</div>
+                <h3 class="mt-2 text-xl font-semibold leading-tight text-white">30 Active Degrees of Freedom</h3>
+                <p class="mt-3 text-sm leading-relaxed text-slate-300">
+                  7 DoF per arm, 6 per leg, 2 in the neck, 2 in the waist. Ultra-robust 3D-printed structural components engineered for repeated drops, falls, and self-recovery.
+                </p>
+              </div>
+              <ul class="mt-6 space-y-2.5 border-t border-white/5 pt-5 text-sm text-slate-300">
+                <li class="flex items-start gap-2.5"><i data-lucide="check" class="mt-0.5 h-4 w-4 flex-shrink-0 text-emerald-300" stroke-width="2.5"></i>Anthropomorphic 30-DoF kinematics</li>
+                <li class="flex items-start gap-2.5"><i data-lucide="check" class="mt-0.5 h-4 w-4 flex-shrink-0 text-emerald-300" stroke-width="2.5"></i>Dynamixel-class actuator integration</li>
+                <li class="flex items-start gap-2.5"><i data-lucide="check" class="mt-0.5 h-4 w-4 flex-shrink-0 text-emerald-300" stroke-width="2.5"></i>Print-in-place tolerancing &amp; assembly</li>
+              </ul>
+            </div>
+
+            <!-- EE -->
+            <div class="card-hover relative rounded-2xl border border-white/10 bg-white/[0.03] p-7 backdrop-blur-xl hover:border-white/20">
+              <div class="flex items-center justify-between">
+                <div class="grid h-12 w-12 place-items-center rounded-xl bg-white/5 ring-1 ring-sky-400/30">
+                  <i data-lucide="cable" class="h-6 w-6 text-sky-300" stroke-width="1.8"></i>
+                </div>
+                <span class="font-mono text-[10px] uppercase tracking-[0.18em] text-slate-400">EE</span>
+              </div>
+              <div class="mt-7">
+                <div class="text-xs font-mono uppercase tracking-[0.18em] text-slate-400">Electrical Engineering</div>
+                <h3 class="mt-2 text-xl font-semibold leading-tight text-white">Jetson Orin NX Onboard Compute</h3>
+                <p class="mt-3 text-sm leading-relaxed text-slate-300">
+                  Stereo fisheye perception, custom power management, and a clean serial bus topology — production-grade electrical design, not a hobby breadboard.
+                </p>
+              </div>
+              <ul class="mt-6 space-y-2.5 border-t border-white/5 pt-5 text-sm text-slate-300">
+                <li class="flex items-start gap-2.5"><i data-lucide="check" class="mt-0.5 h-4 w-4 flex-shrink-0 text-sky-300" stroke-width="2.5"></i>Stereo fisheye camera pipeline</li>
+                <li class="flex items-start gap-2.5"><i data-lucide="check" class="mt-0.5 h-4 w-4 flex-shrink-0 text-sky-300" stroke-width="2.5"></i>Custom DC power distribution</li>
+                <li class="flex items-start gap-2.5"><i data-lucide="check" class="mt-0.5 h-4 w-4 flex-shrink-0 text-sky-300" stroke-width="2.5"></i>Smart-bus actuator daisy-chain</li>
+              </ul>
+            </div>
+
+            <!-- AI -->
+            <div class="card-hover relative rounded-2xl border border-white/10 bg-white/[0.03] p-7 backdrop-blur-xl hover:border-white/20">
+              <div class="flex items-center justify-between">
+                <div class="grid h-12 w-12 place-items-center rounded-xl bg-white/5 ring-1 ring-emerald-400/30">
+                  <i data-lucide="brain" class="h-6 w-6 text-emerald-300" stroke-width="1.8"></i>
+                </div>
+                <span class="font-mono text-[10px] uppercase tracking-[0.18em] text-slate-400">CS / AI</span>
+              </div>
+              <div class="mt-7">
+                <div class="text-xs font-mono uppercase tracking-[0.18em] text-slate-400">Computer Science &amp; AI</div>
+                <h3 class="mt-2 text-xl font-semibold leading-tight text-white">Sim-to-Real Reinforcement Learning</h3>
+                <p class="mt-3 text-sm leading-relaxed text-slate-300">
+                  Build a faithful MuJoCo / MJX digital twin, identify system dynamics, and train RL walking policies that transfer to the real chassis.
+                </p>
+              </div>
+              <ul class="mt-6 space-y-2.5 border-t border-white/5 pt-5 text-sm text-slate-300">
+                <li class="flex items-start gap-2.5"><i data-lucide="check" class="mt-0.5 h-4 w-4 flex-shrink-0 text-emerald-300" stroke-width="2.5"></i>MuJoCo + MJX physics simulation</li>
+                <li class="flex items-start gap-2.5"><i data-lucide="check" class="mt-0.5 h-4 w-4 flex-shrink-0 text-emerald-300" stroke-width="2.5"></i>System identification (sysID)</li>
+                <li class="flex items-start gap-2.5"><i data-lucide="check" class="mt-0.5 h-4 w-4 flex-shrink-0 text-emerald-300" stroke-width="2.5"></i>RL omnidirectional locomotion</li>
+              </ul>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- =========================== PROGRAM ============================ -->
+      <section id="program" class="relative py-24 md:py-32">
+        <div class="mx-auto max-w-7xl px-6">
+          <div class="flex flex-col items-start justify-between gap-6 md:flex-row md:items-end">
+            <div class="max-w-2xl">
+              <div class="inline-flex items-center gap-2 text-xs font-mono uppercase tracking-[0.2em] text-emerald-300/90">
+                <span class="h-1.5 w-1.5 rounded-full bg-emerald-400 shadow-[0_0_12px_2px_rgba(52,211,153,0.7)]"></span>
+                Program Structure
+              </div>
+              <h2 class="mt-5 text-3xl font-bold tracking-tight text-white md:text-5xl">
+                Two phases. One robot. <span class="bg-gradient-to-r from-emerald-300 to-sky-300 bg-clip-text text-transparent">Six hours a week.</span>
+              </h2>
+            </div>
+            <div class="flex items-center gap-2 rounded-full border border-white/10 bg-white/[0.03] px-4 py-2 text-xs font-mono uppercase tracking-[0.18em] text-slate-300 backdrop-blur-md">
+              <i data-lucide="clock" class="h-3.5 w-3.5 text-emerald-300"></i>
+              6 hr / week · 20 weeks total
+            </div>
+          </div>
+
+          <!-- Tabs -->
+          <div class="mt-12 inline-flex rounded-2xl border border-white/10 bg-white/[0.03] p-1.5 backdrop-blur-md">
+            <button class="phase-btn active relative rounded-xl px-5 py-2.5 text-sm font-medium text-slate-300 transition-all duration-300 hover:text-white" data-phase="summer">
+              <span class="phase-pill"></span>
+              <span class="phase-content flex items-center gap-2">
+                <span class="font-mono text-[10px] uppercase tracking-[0.18em] opacity-70">Phase 01</span>
+                Summer Intensive
+              </span>
+            </button>
+            <button class="phase-btn relative rounded-xl px-5 py-2.5 text-sm font-medium text-slate-300 transition-all duration-300 hover:text-white" data-phase="fall">
+              <span class="phase-pill"></span>
+              <span class="phase-content flex items-center gap-2">
+                <span class="font-mono text-[10px] uppercase tracking-[0.18em] opacity-70">Phase 02</span>
+                Fall Academy
+              </span>
+            </button>
+          </div>
+
+          <!-- Phase: Summer -->
+          <div class="phase-panel active mt-8 overflow-hidden rounded-2xl border border-white/10 bg-white/[0.03] backdrop-blur-xl lg:grid-cols-[1.1fr_1fr]" data-panel="summer">
+            <div class="relative p-8 md:p-10">
+              <div class="flex items-center gap-3">
+                <div class="grid h-12 w-12 place-items-center rounded-xl bg-emerald-400/10 ring-1 ring-emerald-400/30">
+                  <i data-lucide="wrench" class="h-6 w-6 text-emerald-300" stroke-width="1.8"></i>
+                </div>
+                <div>
+                  <div class="font-mono text-[10px] uppercase tracking-[0.18em] text-slate-400">Jun – Aug · 8 Weeks</div>
+                  <h3 class="text-2xl font-semibold text-white">Summer Intensive <span class="text-slate-400">— The Physical Build</span></h3>
+                </div>
+              </div>
+              <div class="mt-8">
+                <div class="text-xs font-mono uppercase tracking-[0.18em] text-emerald-300">End-of-phase milestone</div>
+                <p class="mt-3 text-base leading-relaxed text-slate-200">
+                  Assemble the complete 30-DoF chassis, wire every electronic subsystem, calibrate joint zero-points, and deploy Python keyframe scripts so the robot performs open-loop push-ups and squats.
+                </p>
+              </div>
+              <div class="mt-8 grid gap-3 sm:grid-cols-3">
+                <div class="rounded-xl border border-white/10 bg-white/[0.02] p-4">
+                  <i data-lucide="sparkles" class="h-4 w-4 text-emerald-300"></i>
+                  <div class="mt-2 text-sm leading-snug text-slate-200">Fully-assembled humanoid chassis</div>
+                </div>
+                <div class="rounded-xl border border-white/10 bg-white/[0.02] p-4">
+                  <i data-lucide="sparkles" class="h-4 w-4 text-emerald-300"></i>
+                  <div class="mt-2 text-sm leading-snug text-slate-200">Calibrated actuator bus &amp; power rails</div>
+                </div>
+                <div class="rounded-xl border border-white/10 bg-white/[0.02] p-4">
+                  <i data-lucide="sparkles" class="h-4 w-4 text-emerald-300"></i>
+                  <div class="mt-2 text-sm leading-snug text-slate-200">Open-loop keyframe motion demos</div>
+                </div>
+              </div>
+            </div>
+            <div class="relative border-t border-white/5 bg-gradient-to-br from-slate-900/50 to-slate-950/50 p-8 md:p-10 lg:border-l lg:border-t-0">
+              <div class="font-mono text-[10px] uppercase tracking-[0.18em] text-slate-400">Weekly cadence</div>
+              <div class="mt-5 space-y-3">
+                <div>
+                  <div class="mb-1.5 flex items-center justify-between text-xs">
+                    <span class="flex items-center gap-1.5 font-mono uppercase tracking-[0.18em] text-emerald-300">
+                      <i data-lucide="wrench" class="h-3 w-3"></i> Summer Intensive
+                    </span>
+                    <span class="text-emerald-300">8 wk</span>
+                  </div>
+                  <div class="h-2 overflow-hidden rounded-full bg-white/5">
+                    <div class="h-full rounded-full bg-gradient-to-r from-emerald-300 to-sky-300 shadow-[0_0_18px_-2px_rgba(52,211,153,0.7)]" style="width: 40%;"></div>
+                  </div>
+                </div>
+                <div>
+                  <div class="mb-1.5 flex items-center justify-between text-xs">
+                    <span class="flex items-center gap-1.5 font-mono uppercase tracking-[0.18em] text-slate-500">
+                      <i data-lucide="brain" class="h-3 w-3"></i> Fall Academy
+                    </span>
+                    <span class="text-slate-500">12 wk</span>
+                  </div>
+                  <div class="h-2 overflow-hidden rounded-full bg-white/5">
+                    <div class="h-full rounded-full bg-white/10" style="width: 60%;"></div>
+                  </div>
+                </div>
+              </div>
+              <div class="mt-8 rounded-xl border border-white/10 bg-slate-950/40 p-5">
+                <div class="flex items-start gap-3">
+                  <i data-lucide="calendar" class="mt-0.5 h-4 w-4 flex-shrink-0 text-sky-300"></i>
+                  <div>
+                    <div class="text-sm font-semibold text-white">Hybrid schedule</div>
+                    <p class="mt-1 text-sm leading-relaxed text-slate-300">In-person lab build sessions on weekends during summer, plus weeknight virtual office hours throughout the fall academy.</p>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <!-- Phase: Fall -->
+          <div class="phase-panel mt-8 overflow-hidden rounded-2xl border border-white/10 bg-white/[0.03] backdrop-blur-xl lg:grid-cols-[1.1fr_1fr]" data-panel="fall">
+            <div class="relative p-8 md:p-10">
+              <div class="flex items-center gap-3">
+                <div class="grid h-12 w-12 place-items-center rounded-xl bg-emerald-400/10 ring-1 ring-emerald-400/30">
+                  <i data-lucide="brain" class="h-6 w-6 text-emerald-300" stroke-width="1.8"></i>
+                </div>
+                <div>
+                  <div class="font-mono text-[10px] uppercase tracking-[0.18em] text-slate-400">Sep – Dec · 12 Weeks</div>
+                  <h3 class="text-2xl font-semibold text-white">Fall Academy <span class="text-slate-400">— The Digital Brain</span></h3>
+                </div>
+              </div>
+              <div class="mt-8">
+                <div class="text-xs font-mono uppercase tracking-[0.18em] text-emerald-300">End-of-phase milestone</div>
+                <p class="mt-3 text-base leading-relaxed text-slate-200">
+                  Stand up a MuJoCo digital twin, perform motor system identification, train RL walking policies in MJX, and explore real-time VR teleoperation or vision-based manipulation.
+                </p>
+              </div>
+              <div class="mt-8 grid gap-3 sm:grid-cols-3">
+                <div class="rounded-xl border border-white/10 bg-white/[0.02] p-4">
+                  <i data-lucide="sparkles" class="h-4 w-4 text-emerald-300"></i>
+                  <div class="mt-2 text-sm leading-snug text-slate-200">MuJoCo digital twin + sysID report</div>
+                </div>
+                <div class="rounded-xl border border-white/10 bg-white/[0.02] p-4">
+                  <i data-lucide="sparkles" class="h-4 w-4 text-emerald-300"></i>
+                  <div class="mt-2 text-sm leading-snug text-slate-200">Trained RL walking policy</div>
+                </div>
+                <div class="rounded-xl border border-white/10 bg-white/[0.02] p-4">
+                  <i data-lucide="sparkles" class="h-4 w-4 text-emerald-300"></i>
+                  <div class="mt-2 text-sm leading-snug text-slate-200">Teleop or manipulation capstone demo</div>
+                </div>
+              </div>
+            </div>
+            <div class="relative border-t border-white/5 bg-gradient-to-br from-slate-900/50 to-slate-950/50 p-8 md:p-10 lg:border-l lg:border-t-0">
+              <div class="font-mono text-[10px] uppercase tracking-[0.18em] text-slate-400">Weekly cadence</div>
+              <div class="mt-5 space-y-3">
+                <div>
+                  <div class="mb-1.5 flex items-center justify-between text-xs">
+                    <span class="flex items-center gap-1.5 font-mono uppercase tracking-[0.18em] text-slate-500">
+                      <i data-lucide="wrench" class="h-3 w-3"></i> Summer Intensive
+                    </span>
+                    <span class="text-slate-500">8 wk</span>
+                  </div>
+                  <div class="h-2 overflow-hidden rounded-full bg-white/5">
+                    <div class="h-full rounded-full bg-white/10" style="width: 40%;"></div>
+                  </div>
+                </div>
+                <div>
+                  <div class="mb-1.5 flex items-center justify-between text-xs">
+                    <span class="flex items-center gap-1.5 font-mono uppercase tracking-[0.18em] text-emerald-300">
+                      <i data-lucide="brain" class="h-3 w-3"></i> Fall Academy
+                    </span>
+                    <span class="text-emerald-300">12 wk</span>
+                  </div>
+                  <div class="h-2 overflow-hidden rounded-full bg-white/5">
+                    <div class="h-full rounded-full bg-gradient-to-r from-emerald-300 to-sky-300 shadow-[0_0_18px_-2px_rgba(52,211,153,0.7)]" style="width: 60%;"></div>
+                  </div>
+                </div>
+              </div>
+              <div class="mt-8 rounded-xl border border-white/10 bg-slate-950/40 p-5">
+                <div class="flex items-start gap-3">
+                  <i data-lucide="calendar" class="mt-0.5 h-4 w-4 flex-shrink-0 text-sky-300"></i>
+                  <div>
+                    <div class="text-sm font-semibold text-white">Hybrid schedule</div>
+                    <p class="mt-1 text-sm leading-relaxed text-slate-300">Weeknight virtual seminars and code reviews, plus monthly in-person lab integration days for sim-to-real testing.</p>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- =========================== SYLLABUS ============================ -->
+      <section id="syllabus" class="relative py-24 md:py-32">
+        <div class="mx-auto max-w-5xl px-6">
+          <div class="max-w-2xl">
+            <div class="inline-flex items-center gap-2 text-xs font-mono uppercase tracking-[0.2em] text-emerald-300/90">
+              <span class="h-1.5 w-1.5 rounded-full bg-emerald-400 shadow-[0_0_12px_2px_rgba(52,211,153,0.7)]"></span>
+              High-Level Syllabus
+            </div>
+            <h2 class="mt-5 text-3xl font-bold tracking-tight text-white md:text-5xl">
+              20 weeks, mapped to <span class="bg-gradient-to-r from-emerald-300 to-sky-300 bg-clip-text text-transparent">real engineering deliverables.</span>
+            </h2>
+            <p class="mt-5 text-base leading-relaxed text-slate-300">
+              Each module is taught lab-first: a short concept primer, then hands-on time on the bench or in simulation, then a code review with your mentor.
+            </p>
+          </div>
+
+          <div class="mt-12 overflow-hidden rounded-2xl border border-white/10 bg-white/[0.02] backdrop-blur-md" id="syllabus-acc">
+
+            <!-- Item 1 -->
+            <div class="acc-item open border-b border-white/5">
+              <button class="acc-toggle group flex w-full items-center gap-4 px-5 py-5 text-left transition-colors hover:bg-white/[0.03] md:px-7">
+                <div class="acc-icon-wrap grid h-10 w-10 flex-shrink-0 place-items-center rounded-lg bg-white/5 text-slate-300 ring-1 ring-white/10 transition-all"><i data-lucide="cog" class="h-5 w-5" stroke-width="1.8"></i></div>
+                <div class="hidden w-28 flex-shrink-0 font-mono text-[11px] uppercase tracking-[0.18em] text-slate-400 sm:block">Weeks 1–2</div>
+                <div class="min-w-0 flex-1">
+                  <div class="flex flex-wrap items-center gap-2">
+                    <span class="text-base font-semibold text-white md:text-lg">Anthropomorphic Design &amp; 3D Printing Tolerances</span>
+                    <span class="rounded-full border border-white/10 px-2 py-0.5 font-mono text-[9px] uppercase tracking-[0.16em] text-slate-400">Summer</span>
+                  </div>
+                  <div class="mt-1 font-mono text-[10px] uppercase tracking-[0.18em] text-slate-500 sm:hidden">Weeks 1–2</div>
+                </div>
+                <i data-lucide="chevron-down" class="acc-chevron h-5 w-5 flex-shrink-0 text-slate-400 transition-transform duration-300"></i>
+              </button>
+              <div class="acc-panel"><div><div class="px-5 pb-6 pl-[68px] text-sm leading-relaxed text-slate-300 md:px-7 md:pl-[180px]">How humanoid linkages distribute mass, why tolerance stacks dominate joint feel, and how to print structural parts that survive a fall.</div></div></div>
+            </div>
+
+            <!-- Item 2 -->
+            <div class="acc-item border-b border-white/5">
+              <button class="acc-toggle group flex w-full items-center gap-4 px-5 py-5 text-left transition-colors hover:bg-white/[0.03] md:px-7">
+                <div class="acc-icon-wrap grid h-10 w-10 flex-shrink-0 place-items-center rounded-lg bg-white/5 text-slate-300 ring-1 ring-white/10 transition-all"><i data-lucide="cable" class="h-5 w-5" stroke-width="1.8"></i></div>
+                <div class="hidden w-28 flex-shrink-0 font-mono text-[11px] uppercase tracking-[0.18em] text-slate-400 sm:block">Weeks 3–4</div>
+                <div class="min-w-0 flex-1">
+                  <div class="flex flex-wrap items-center gap-2">
+                    <span class="text-base font-semibold text-white md:text-lg">Actuator Calibration, Bus Comms &amp; Power Schematics</span>
+                    <span class="rounded-full border border-white/10 px-2 py-0.5 font-mono text-[9px] uppercase tracking-[0.16em] text-slate-400">Summer</span>
+                  </div>
+                  <div class="mt-1 font-mono text-[10px] uppercase tracking-[0.18em] text-slate-500 sm:hidden">Weeks 3–4</div>
+                </div>
+                <i data-lucide="chevron-down" class="acc-chevron h-5 w-5 flex-shrink-0 text-slate-400 transition-transform duration-300"></i>
+              </button>
+              <div class="acc-panel"><div><div class="px-5 pb-6 pl-[68px] text-sm leading-relaxed text-slate-300 md:px-7 md:pl-[180px]">Read datasheets like an engineer. Build a clean serial-bus topology, set actuator IDs, and design a power distribution diagram that won't brown-out under load.</div></div></div>
+            </div>
+
+            <!-- Item 3 -->
+            <div class="acc-item border-b border-white/5">
+              <button class="acc-toggle group flex w-full items-center gap-4 px-5 py-5 text-left transition-colors hover:bg-white/[0.03] md:px-7">
+                <div class="acc-icon-wrap grid h-10 w-10 flex-shrink-0 place-items-center rounded-lg bg-white/5 text-slate-300 ring-1 ring-white/10 transition-all"><i data-lucide="cpu" class="h-5 w-5" stroke-width="1.8"></i></div>
+                <div class="hidden w-28 flex-shrink-0 font-mono text-[11px] uppercase tracking-[0.18em] text-slate-400 sm:block">Weeks 5–6</div>
+                <div class="min-w-0 flex-1">
+                  <div class="flex flex-wrap items-center gap-2">
+                    <span class="text-base font-semibold text-white md:text-lg">Full Chassis Mechatronics &amp; Jetson Orin NX Setup</span>
+                    <span class="rounded-full border border-white/10 px-2 py-0.5 font-mono text-[9px] uppercase tracking-[0.16em] text-slate-400">Summer</span>
+                  </div>
+                  <div class="mt-1 font-mono text-[10px] uppercase tracking-[0.18em] text-slate-500 sm:hidden">Weeks 5–6</div>
+                </div>
+                <i data-lucide="chevron-down" class="acc-chevron h-5 w-5 flex-shrink-0 text-slate-400 transition-transform duration-300"></i>
+              </button>
+              <div class="acc-panel"><div><div class="px-5 pb-6 pl-[68px] text-sm leading-relaxed text-slate-300 md:px-7 md:pl-[180px]">Mate the printed skeleton, route every cable, flash the Jetson, and stand up the on-robot software stack end-to-end.</div></div></div>
+            </div>
+
+            <!-- Item 4 -->
+            <div class="acc-item border-b border-white/5">
+              <button class="acc-toggle group flex w-full items-center gap-4 px-5 py-5 text-left transition-colors hover:bg-white/[0.03] md:px-7">
+                <div class="acc-icon-wrap grid h-10 w-10 flex-shrink-0 place-items-center rounded-lg bg-white/5 text-slate-300 ring-1 ring-white/10 transition-all"><i data-lucide="bot" class="h-5 w-5" stroke-width="1.8"></i></div>
+                <div class="hidden w-28 flex-shrink-0 font-mono text-[11px] uppercase tracking-[0.18em] text-slate-400 sm:block">Weeks 7–8</div>
+                <div class="min-w-0 flex-1">
+                  <div class="flex flex-wrap items-center gap-2">
+                    <span class="text-base font-semibold text-white md:text-lg">Kinematics &amp; Python Keyframe Motion Control</span>
+                    <span class="inline-flex items-center gap-1 rounded-full border border-emerald-400/30 bg-emerald-400/10 px-2 py-0.5 font-mono text-[9px] uppercase tracking-[0.16em] text-emerald-200"><i data-lucide="award" class="h-2.5 w-2.5"></i>Milestone</span>
+                    <span class="rounded-full border border-white/10 px-2 py-0.5 font-mono text-[9px] uppercase tracking-[0.16em] text-slate-400">Summer</span>
+                  </div>
+                  <div class="mt-1 font-mono text-[10px] uppercase tracking-[0.18em] text-slate-500 sm:hidden">Weeks 7–8</div>
+                </div>
+                <i data-lucide="chevron-down" class="acc-chevron h-5 w-5 flex-shrink-0 text-slate-400 transition-transform duration-300"></i>
+              </button>
+              <div class="acc-panel"><div><div class="px-5 pb-6 pl-[68px] text-sm leading-relaxed text-slate-300 md:px-7 md:pl-[180px]">Forward kinematics, joint-space trajectories, and a keyframe app that drives the real hardware. Summer milestone: live push-ups and squats.</div></div></div>
+            </div>
+
+            <!-- Item 5 -->
+            <div class="acc-item border-b border-white/5">
+              <button class="acc-toggle group flex w-full items-center gap-4 px-5 py-5 text-left transition-colors hover:bg-white/[0.03] md:px-7">
+                <div class="acc-icon-wrap grid h-10 w-10 flex-shrink-0 place-items-center rounded-lg bg-white/5 text-slate-300 ring-1 ring-white/10 transition-all"><i data-lucide="flask-conical" class="h-5 w-5" stroke-width="1.8"></i></div>
+                <div class="hidden w-28 flex-shrink-0 font-mono text-[11px] uppercase tracking-[0.18em] text-slate-400 sm:block">Weeks 9–12</div>
+                <div class="min-w-0 flex-1">
+                  <div class="flex flex-wrap items-center gap-2">
+                    <span class="text-base font-semibold text-white md:text-lg">Digital Twins in MuJoCo &amp; System Identification</span>
+                    <span class="rounded-full border border-white/10 px-2 py-0.5 font-mono text-[9px] uppercase tracking-[0.16em] text-slate-400">Fall</span>
+                  </div>
+                  <div class="mt-1 font-mono text-[10px] uppercase tracking-[0.18em] text-slate-500 sm:hidden">Weeks 9–12</div>
+                </div>
+                <i data-lucide="chevron-down" class="acc-chevron h-5 w-5 flex-shrink-0 text-slate-400 transition-transform duration-300"></i>
+              </button>
+              <div class="acc-panel"><div><div class="px-5 pb-6 pl-[68px] text-sm leading-relaxed text-slate-300 md:px-7 md:pl-[180px]">Build the simulated twin of your own robot, then identify its true dynamics so simulation actually predicts reality.</div></div></div>
+            </div>
+
+            <!-- Item 6 -->
+            <div class="acc-item border-b border-white/5">
+              <button class="acc-toggle group flex w-full items-center gap-4 px-5 py-5 text-left transition-colors hover:bg-white/[0.03] md:px-7">
+                <div class="acc-icon-wrap grid h-10 w-10 flex-shrink-0 place-items-center rounded-lg bg-white/5 text-slate-300 ring-1 ring-white/10 transition-all"><i data-lucide="brain" class="h-5 w-5" stroke-width="1.8"></i></div>
+                <div class="hidden w-28 flex-shrink-0 font-mono text-[11px] uppercase tracking-[0.18em] text-slate-400 sm:block">Weeks 13–16</div>
+                <div class="min-w-0 flex-1">
+                  <div class="flex flex-wrap items-center gap-2">
+                    <span class="text-base font-semibold text-white md:text-lg">RL: Omnidirectional Locomotion Policies in MJX</span>
+                    <span class="rounded-full border border-white/10 px-2 py-0.5 font-mono text-[9px] uppercase tracking-[0.16em] text-slate-400">Fall</span>
+                  </div>
+                  <div class="mt-1 font-mono text-[10px] uppercase tracking-[0.18em] text-slate-500 sm:hidden">Weeks 13–16</div>
+                </div>
+                <i data-lucide="chevron-down" class="acc-chevron h-5 w-5 flex-shrink-0 text-slate-400 transition-transform duration-300"></i>
+              </button>
+              <div class="acc-panel"><div><div class="px-5 pb-6 pl-[68px] text-sm leading-relaxed text-slate-300 md:px-7 md:pl-[180px]">PPO-style reinforcement learning, reward shaping, and large-scale parallel rollouts in MJX to train a policy that walks.</div></div></div>
+            </div>
+
+            <!-- Item 7 -->
+            <div class="acc-item">
+              <button class="acc-toggle group flex w-full items-center gap-4 px-5 py-5 text-left transition-colors hover:bg-white/[0.03] md:px-7">
+                <div class="acc-icon-wrap grid h-10 w-10 flex-shrink-0 place-items-center rounded-lg bg-white/5 text-slate-300 ring-1 ring-white/10 transition-all"><i data-lucide="graduation-cap" class="h-5 w-5" stroke-width="1.8"></i></div>
+                <div class="hidden w-28 flex-shrink-0 font-mono text-[11px] uppercase tracking-[0.18em] text-slate-400 sm:block">Weeks 17–20</div>
+                <div class="min-w-0 flex-1">
+                  <div class="flex flex-wrap items-center gap-2">
+                    <span class="text-base font-semibold text-white md:text-lg">Sim-to-Real Transfer, Evaluation &amp; Portfolio Presentation</span>
+                    <span class="inline-flex items-center gap-1 rounded-full border border-emerald-400/30 bg-emerald-400/10 px-2 py-0.5 font-mono text-[9px] uppercase tracking-[0.16em] text-emerald-200"><i data-lucide="award" class="h-2.5 w-2.5"></i>Milestone</span>
+                    <span class="rounded-full border border-white/10 px-2 py-0.5 font-mono text-[9px] uppercase tracking-[0.16em] text-slate-400">Fall</span>
+                  </div>
+                  <div class="mt-1 font-mono text-[10px] uppercase tracking-[0.18em] text-slate-500 sm:hidden">Weeks 17–20</div>
+                </div>
+                <i data-lucide="chevron-down" class="acc-chevron h-5 w-5 flex-shrink-0 text-slate-400 transition-transform duration-300"></i>
+              </button>
+              <div class="acc-panel"><div><div class="px-5 pb-6 pl-[68px] text-sm leading-relaxed text-slate-300 md:px-7 md:pl-[180px]">Deploy your policy on the physical robot, measure the reality gap, and produce a research-quality writeup for your portfolio.</div></div></div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- =========================== MENTORSHIP =========================== -->
+      <section id="mentorship" class="relative py-24 md:py-32">
+        <div class="mx-auto max-w-7xl px-6">
+          <div class="overflow-hidden rounded-2xl border border-white/10 bg-white/[0.03] backdrop-blur-xl">
+            <div class="grid lg:grid-cols-[1.2fr_1fr]">
+              <div class="relative p-8 md:p-12">
+                <div class="inline-flex items-center gap-2 text-xs font-mono uppercase tracking-[0.2em] text-emerald-300/90">
+                  <span class="h-1.5 w-1.5 rounded-full bg-emerald-400 shadow-[0_0_12px_2px_rgba(52,211,153,0.7)]"></span>
+                  The Mentorship Advantage
+                </div>
+                <h2 class="mt-5 text-3xl font-bold tracking-tight text-white md:text-5xl">
+                  You're not following a tutorial. <span class="bg-gradient-to-r from-emerald-300 to-sky-300 bg-clip-text text-transparent">You're shipping research.</span>
+                </h2>
+                <p class="mt-5 max-w-xl text-base leading-relaxed text-slate-300">
+                  Every cohort student builds against the same platform Stanford's research team publishes on. Your code, sims, and hardware get reviewed by the people who wrote the paper.
+                </p>
+
+                <div class="mt-10 space-y-5">
+                  <div class="flex gap-4">
+                    <div class="grid h-10 w-10 flex-shrink-0 place-items-center rounded-lg bg-emerald-400/10 ring-1 ring-emerald-400/30">
+                      <i data-lucide="shield-check" class="h-5 w-5 text-emerald-300" stroke-width="1.8"></i>
+                    </div>
+                    <div>
+                      <div class="font-semibold text-white">Direct technical consultation</div>
+                      <p class="mt-1 text-sm leading-relaxed text-slate-300">The 1st and 2nd authors of the original ToddlerBot paper serve as Technical Consultants — reviewing student code, simulation designs, and hardware builds.</p>
+                    </div>
+                  </div>
+                  <div class="flex gap-4">
+                    <div class="grid h-10 w-10 flex-shrink-0 place-items-center rounded-lg bg-emerald-400/10 ring-1 ring-emerald-400/30">
+                      <i data-lucide="users" class="h-5 w-5 text-emerald-300" stroke-width="1.8"></i>
+                    </div>
+                    <div>
+                      <div class="font-semibold text-white">Genboo engineers as lead mentors</div>
+                      <p class="mt-1 text-sm leading-relaxed text-slate-300">Working roboticists run weekly labs, code reviews, and 1:1s. Maximum 5 students per mentor so feedback is dense and personal.</p>
+                    </div>
+                  </div>
+                  <div class="flex gap-4">
+                    <div class="grid h-10 w-10 flex-shrink-0 place-items-center rounded-lg bg-emerald-400/10 ring-1 ring-emerald-400/30">
+                      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="h-5 w-5 text-emerald-300" aria-hidden="true">
+                        <path d="M12 .5C5.73.5.67 5.57.67 11.85c0 5.02 3.24 9.27 7.74 10.77.57.11.78-.25.78-.55v-2.13c-3.15.69-3.82-1.34-3.82-1.34-.51-1.31-1.26-1.66-1.26-1.66-1.03-.7.08-.69.08-.69 1.14.08 1.74 1.17 1.74 1.17 1.01 1.74 2.66 1.24 3.31.95.1-.74.4-1.24.72-1.53-2.51-.29-5.16-1.27-5.16-5.65 0-1.25.45-2.27 1.17-3.08-.12-.3-.51-1.46.11-3.05 0 0 .97-.31 3.18 1.18a11 11 0 0 1 2.9-.39c.98 0 1.97.13 2.9.39 2.2-1.49 3.17-1.18 3.17-1.18.63 1.59.23 2.75.11 3.05.73.81 1.17 1.83 1.17 3.08 0 4.39-2.66 5.36-5.18 5.64.41.36.78 1.06.78 2.13v3.16c0 .31.21.67.79.55 4.49-1.5 7.73-5.75 7.73-10.77C23.33 5.57 18.27.5 12 .5z"/>
+                      </svg>
+                    </div>
+                    <div>
+                      <div class="font-semibold text-white">Real open-source contributions</div>
+                      <p class="mt-1 text-sm leading-relaxed text-slate-300">Your improvements to drivers, sim tooling, and policies can land upstream in the ToddlerBot repository — a portfolio piece that compounds.</p>
+                    </div>
+                  </div>
+                </div>
+              </div>
+
+              <div class="relative overflow-hidden border-t border-white/5 bg-gradient-to-br from-slate-900/40 to-slate-950/60 p-8 md:p-12 lg:border-l lg:border-t-0">
+                <div class="pointer-events-none absolute -right-20 -top-20 h-72 w-72 rounded-full bg-emerald-500/20 blur-[100px]"></div>
+                <div class="pointer-events-none absolute -left-10 bottom-0 h-60 w-60 rounded-full bg-sky-500/15 blur-[100px]"></div>
+
+                <div class="relative">
+                  <div class="font-mono text-[10px] uppercase tracking-[0.18em] text-slate-400">Source platform</div>
+                  <a href="https://toddlerbot.github.io/" target="_blank" rel="noreferrer" class="mt-3 inline-flex items-center gap-2 text-2xl font-semibold text-white hover:text-emerald-300">
+                    ToddlerBot
+                    <i data-lucide="arrow-up-right" class="h-5 w-5"></i>
+                  </a>
+                  <p class="mt-2 text-sm text-slate-400">Stanford-published open-source humanoid research platform.</p>
+
+                  <div class="mt-8 space-y-3">
+                    <div class="flex items-center justify-between rounded-lg border border-white/10 bg-white/[0.02] px-4 py-3">
+                      <span class="font-mono text-[10px] uppercase tracking-[0.18em] text-slate-400">Active DoFs</span>
+                      <span class="text-sm font-medium text-white">30</span>
+                    </div>
+                    <div class="flex items-center justify-between rounded-lg border border-white/10 bg-white/[0.02] px-4 py-3">
+                      <span class="font-mono text-[10px] uppercase tracking-[0.18em] text-slate-400">Compute</span>
+                      <span class="text-sm font-medium text-white">Jetson Orin NX</span>
+                    </div>
+                    <div class="flex items-center justify-between rounded-lg border border-white/10 bg-white/[0.02] px-4 py-3">
+                      <span class="font-mono text-[10px] uppercase tracking-[0.18em] text-slate-400">Perception</span>
+                      <span class="text-sm font-medium text-white">Stereo fisheye</span>
+                    </div>
+                    <div class="flex items-center justify-between rounded-lg border border-white/10 bg-white/[0.02] px-4 py-3">
+                      <span class="font-mono text-[10px] uppercase tracking-[0.18em] text-slate-400">Sim</span>
+                      <span class="text-sm font-medium text-white">MuJoCo + MJX</span>
+                    </div>
+                    <div class="flex items-center justify-between rounded-lg border border-white/10 bg-white/[0.02] px-4 py-3">
+                      <span class="font-mono text-[10px] uppercase tracking-[0.18em] text-slate-400">Policy</span>
+                      <span class="text-sm font-medium text-white">RL omnidirectional</span>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- =========================== APPLY ============================ -->
+      <section id="apply" class="relative py-24 md:py-32">
+        <div class="mx-auto max-w-6xl px-6">
+          <div class="relative overflow-hidden rounded-3xl border border-white/10 bg-white/[0.03] backdrop-blur-xl">
+            <div class="pointer-events-none absolute inset-0">
+              <div class="absolute -left-32 -top-32 h-96 w-96 rounded-full bg-emerald-500/25 blur-[140px]"></div>
+              <div class="absolute -right-32 -bottom-32 h-96 w-96 rounded-full bg-sky-500/20 blur-[140px]"></div>
+              <div class="dot-grid absolute inset-0 opacity-[0.12]"></div>
+            </div>
+
+            <div class="relative grid gap-10 p-8 md:p-12 lg:grid-cols-[1.05fr_1fr] lg:gap-14">
+              <div>
+                <div class="inline-flex items-center gap-2 text-xs font-mono uppercase tracking-[0.2em] text-emerald-300/90">
+                  <span class="h-1.5 w-1.5 rounded-full bg-emerald-400 shadow-[0_0_12px_2px_rgba(52,211,153,0.7)]"></span>
+                  Apply · Cohort 01
+                </div>
+                <h2 class="mt-5 text-3xl font-bold tracking-tight text-white md:text-5xl">
+                  Seats are <span class="bg-gradient-to-r from-emerald-300 to-sky-300 bg-clip-text text-transparent">strictly limited.</span>
+                </h2>
+                <p class="mt-5 max-w-xl text-base leading-relaxed text-slate-300">
+                  Due to hardware complexity and lab space constraints, this cohort is highly selective. Ideal candidates have prior exposure to programming
+                  <span class="font-mono text-emerald-200">(Python / C++)</span> or competitive robotics
+                  <span class="font-mono text-emerald-200">(VEX / FRC)</span> — but passion and problem-solving drive are prioritized over credentials.
+                </p>
+                <div class="mt-8 space-y-3">
+                  <div class="flex items-start gap-3 text-sm text-slate-300"><i data-lucide="check" class="mt-0.5 h-4 w-4 flex-shrink-0 text-emerald-300" stroke-width="2.5"></i>Open to current high school students (grades 9–12).</div>
+                  <div class="flex items-start gap-3 text-sm text-slate-300"><i data-lucide="check" class="mt-0.5 h-4 w-4 flex-shrink-0 text-emerald-300" stroke-width="2.5"></i>Rolling admissions — earlier applicants get priority lab access.</div>
+                  <div class="flex items-start gap-3 text-sm text-slate-300"><i data-lucide="check" class="mt-0.5 h-4 w-4 flex-shrink-0 text-emerald-300" stroke-width="2.5"></i>Need-based scholarships available for hardware kit costs.</div>
+                </div>
+              </div>
+
+              <div class="rounded-2xl border border-white/10 bg-slate-950/60 p-7 backdrop-blur-xl">
+                <form id="apply-form" class="space-y-4" action="https://formspree.io/f/xqabbeeb" method="POST">
+                  <div class="font-mono text-[10px] uppercase tracking-[0.18em] text-emerald-300">Express interest</div>
+                  <h3 class="text-xl font-semibold text-white">Start your application</h3>
+                  <div class="space-y-3 pt-2">
+                    <input required name="name" type="text" placeholder="Full name" class="w-full rounded-xl border border-white/10 bg-white/[0.03] px-4 py-3 text-sm text-white placeholder:text-slate-500 focus:border-emerald-400/50 focus:outline-none focus:ring-2 focus:ring-emerald-400/20" />
+                    <input required name="email" type="email" placeholder="Email" class="w-full rounded-xl border border-white/10 bg-white/[0.03] px-4 py-3 text-sm text-white placeholder:text-slate-500 focus:border-emerald-400/50 focus:outline-none focus:ring-2 focus:ring-emerald-400/20" />
+                    <input required name="school" type="text" placeholder="School & grade" class="w-full rounded-xl border border-white/10 bg-white/[0.03] px-4 py-3 text-sm text-white placeholder:text-slate-500 focus:border-emerald-400/50 focus:outline-none focus:ring-2 focus:ring-emerald-400/20" />
+                    <textarea name="note" rows="3" placeholder="A robotics project, repo, or build you're proud of (optional)" class="w-full resize-none rounded-xl border border-white/10 bg-white/[0.03] px-4 py-3 text-sm text-white placeholder:text-slate-500 focus:border-emerald-400/50 focus:outline-none focus:ring-2 focus:ring-emerald-400/20"></textarea>
+                  </div>
+
+                  <!-- Hidden routing fields -->
+                  <input type="hidden" name="program" value="Humanoid Cohort 01" />
+                  <input type="hidden" name="source" value="humanoid.genboo.com" />
+                  <input type="hidden" name="_subject" value="Humanoid Cohort Application" />
+                  <!-- Honeypot -->
+                  <input type="text" name="_gotcha" tabindex="-1" autocomplete="off" style="position:absolute;left:-9999px;width:1px;height:1px;opacity:0;" aria-hidden="true" />
+
+                  <button id="apply-submit" type="submit" class="glow-cta group relative mt-2 inline-flex w-full items-center justify-center gap-2 rounded-xl px-6 py-3.5 text-sm font-semibold text-slate-950 disabled:cursor-not-allowed disabled:opacity-70">
+                    <span class="glow-cta-bg"></span>
+                    <span class="glow-cta-inner flex items-center gap-2">
+                      <span id="apply-submit-label">Submit Application</span>
+                      <i id="apply-submit-arrow" data-lucide="arrow-right" class="h-4 w-4 transition-transform group-hover:translate-x-0.5"></i>
+                    </span>
+                  </button>
+                  <p id="apply-error" class="hidden pt-1 text-center text-[12px] text-rose-300">Something went wrong. Please email <a class="underline" href="mailto:hello@genboo.com">hello@genboo.com</a>.</p>
+                  <p class="pt-1 text-center text-[11px] text-slate-500">We'll follow up within 5 business days with next steps.</p>
+                </form>
+
+                <div id="apply-success" class="hidden flex-col items-center py-10 text-center">
+                  <div class="grid h-14 w-14 place-items-center rounded-full bg-emerald-400/15 ring-1 ring-emerald-400/40">
+                    <i data-lucide="check" class="h-7 w-7 text-emerald-300" stroke-width="2.5"></i>
+                  </div>
+                  <h3 class="mt-5 text-xl font-semibold text-white">Application received</h3>
+                  <p class="mt-2 max-w-xs text-sm text-slate-300">Thanks, <span id="apply-name">future roboticist</span>. We'll reach out within 5 business days.</p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <!-- =========================== FOOTER ============================ -->
+    <footer class="relative border-t border-white/5 bg-slate-950/60 py-10 backdrop-blur-xl">
+      <div class="mx-auto flex max-w-7xl flex-col items-center justify-between gap-4 px-6 md:flex-row">
+        <div class="flex items-center gap-2.5">
+          <span class="logo-mark relative grid h-8 w-8 place-items-center rounded-lg">
+            <span class="logo-cjk relative z-10 text-[11px]">
+              <span>进</span>
+              <span>步</span>
+            </span>
+          </span>
+          <div class="leading-tight">
+            <div class="text-sm font-semibold text-white">Genboo · <span class="font-cjk text-emerald-300">进步</span></div>
+            <div class="font-mono text-[10px] uppercase tracking-[0.18em] text-slate-400">© 2026 Genboo</div>
+          </div>
+        </div>
+        <div class="flex flex-wrap items-center justify-center gap-5 text-xs text-slate-400">
+          <a href="mailto:hello@genboo.com" class="inline-flex items-center gap-1.5 hover:text-emerald-300"><i data-lucide="mail" class="h-3.5 w-3.5"></i>hello@genboo.com</a>
+          <span class="inline-flex items-center gap-1.5"><i data-lucide="map-pin" class="h-3.5 w-3.5"></i>Bay Area, CA</span>
+          <a href="https://toddlerbot.github.io/" target="_blank" rel="noreferrer" class="inline-flex items-center gap-1.5 hover:text-emerald-300">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="h-3.5 w-3.5" aria-hidden="true">
+              <path d="M12 .5C5.73.5.67 5.57.67 11.85c0 5.02 3.24 9.27 7.74 10.77.57.11.78-.25.78-.55v-2.13c-3.15.69-3.82-1.34-3.82-1.34-.51-1.31-1.26-1.66-1.26-1.66-1.03-.7.08-.69.08-.69 1.14.08 1.74 1.17 1.74 1.17 1.01 1.74 2.66 1.24 3.31.95.1-.74.4-1.24.72-1.53-2.51-.29-5.16-1.27-5.16-5.65 0-1.25.45-2.27 1.17-3.08-.12-.3-.51-1.46.11-3.05 0 0 .97-.31 3.18 1.18a11 11 0 0 1 2.9-.39c.98 0 1.97.13 2.9.39 2.2-1.49 3.17-1.18 3.17-1.18.63 1.59.23 2.75.11 3.05.73.81 1.17 1.83 1.17 3.08 0 4.39-2.66 5.36-5.18 5.64.41.36.78 1.06.78 2.13v3.16c0 .31.21.67.79.55 4.49-1.5 7.73-5.75 7.73-10.77C23.33 5.57 18.27.5 12 .5z"/>
+            </svg>
+            ToddlerBot
+          </a>
+        </div>
+      </div>
+    </footer>
+
+    <!-- Lucide Icons -->
+    <script src="https://unpkg.com/lucide@latest"></script>
+    <script>
+      // Render lucide icons
+      lucide.createIcons();
+
+      // Accordion
+      document.querySelectorAll('#syllabus-acc .acc-item').forEach((item) => {
+        const btn = item.querySelector('.acc-toggle');
+        btn.addEventListener('click', () => {
+          const isOpen = item.classList.contains('open');
+          document.querySelectorAll('#syllabus-acc .acc-item').forEach((i) => i.classList.remove('open'));
+          if (!isOpen) item.classList.add('open');
+        });
+      });
+
+      // Phase tab switcher
+      document.querySelectorAll('.phase-btn').forEach((btn) => {
+        btn.addEventListener('click', () => {
+          const phase = btn.dataset.phase;
+          document.querySelectorAll('.phase-btn').forEach((b) => b.classList.toggle('active', b === btn));
+          document.querySelectorAll('.phase-panel').forEach((p) => p.classList.toggle('active', p.dataset.panel === phase));
+        });
+      });
+
+      // Apply form -> POST to Formspree, then show inline success
+      const form = document.getElementById('apply-form');
+      const success = document.getElementById('apply-success');
+      const errEl = document.getElementById('apply-error');
+      const submitBtn = document.getElementById('apply-submit');
+      const submitLabel = document.getElementById('apply-submit-label');
+
+      form.addEventListener('submit', async (e) => {
+        e.preventDefault();
+        errEl.classList.add('hidden');
+        submitBtn.disabled = true;
+        const prevLabel = submitLabel.textContent;
+        submitLabel.textContent = 'Sending…';
+
+        try {
+          const data = new FormData(form);
+          const res = await fetch(form.action, {
+            method: 'POST',
+            body: data,
+            headers: { 'Accept': 'application/json' },
+          });
+          if (!res.ok) throw new Error('Formspree responded ' + res.status);
+
+          const name = data.get('name') || '';
+          const first = String(name).trim().split(/\s+/)[0];
+          if (first) document.getElementById('apply-name').textContent = first;
+          form.classList.add('hidden');
+          success.classList.remove('hidden');
+          success.classList.add('flex');
+        } catch (err) {
+          console.error(err);
+          errEl.classList.remove('hidden');
+          submitBtn.disabled = false;
+          submitLabel.textContent = prevLabel;
+        }
+      });
+    </script>
+  </body>
+</html>

--- a/index.html
+++ b/index.html
@@ -1,17 +1,16 @@
 <!DOCTYPE html>
 <html lang="en">
 <!--
-KEY CHANGES:
-1. Navigation updated: Programs, Competition Team, Learning Approach, Outcomes, FAQ, Register
-2. Programs restructured by grade bands: Casual Robotics (Grade 1/2/3+) + Competition Team (separate prominent section)
-3. Learning Approach section rewritten with ENGR 391 learning science principles (constructivism, inquiry cycle, scaffolding, formative assessment, feedback loops)
-4. Added "How We Track Progress" subsection explaining homework system and parent reports
-5. Added new Outcomes section with metric-like bullets and showcase gallery placeholder
-6. About/Team section tightened with "Parent-led, research-informed" and safety note
-7. Registration updated with new program selector matching grade bands
-8. Added comprehensive FAQ section with 10 questions
-9. Cleaned up duplicated CSS (.company-logo, .separator), improved mobile spacing
-10. Added sticky mobile CTA bar, reduced card min-heights, improved 375px width experience
+KEY CHANGES (Encord-inspired redesign):
+1. Pitch-black/charcoal palette with electric teal accent and subtle radial glows
+2. Inter typeface + JetBrains Mono for technical labels and tags
+3. Bento-style modular grids with razor-thin borders (1px separators)
+4. Glowing pill badge in hero with pulsing dot
+5. Sharp 8px corners (no bubbly rounding), monochrome inverted partner logos
+6. Glassmorphism navigation with backdrop blur
+7. Snappy 0.2s cubic-bezier transitions on all interactives
+8. Monospace section labels with accent dot, refined hover states
+9. Preserved: all copy, asset paths, form action, IDs, mobile menu, FAQ accordion, WeChat fallback, sticky CTA
 -->
 <head>
     <!-- Google tag (gtag.js) -->
@@ -25,8 +24,11 @@ KEY CHANGES:
     </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Genboo Robotics - Building Tomorrow's Inventors</title>
+    <title>Genboo Robotics — Building Tomorrow's Inventors</title>
     <link rel="icon" type="image/x-icon" href="genboo_favicon_padded.ico">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
     <style>
         * {
             margin: 0;
@@ -35,27 +37,59 @@ KEY CHANGES:
         }
 
         :root {
-            --primary: #0A0A0A;
-            --secondary: #F5F5F5;
-            --accent: #6366F1;
-            --accent-dark: #4338CA;
-            --text-primary: #0A0A0A;
-            --text-secondary: #333333;
-            --text-tertiary: #666666;
-            --border: #F3F4F6;
-            --hover: #EEF2FF;
-            --gradient: linear-gradient(135deg, #0066FF 0%, #0052CC 100%);
-            --success: #10B981;
+            --bg: #07080C;
+            --bg-elevated: #0B0E15;
+            --surface: #11141C;
+            --surface-hover: #161A24;
+            --border: #1F2530;
+            --border-strong: #2A3344;
+            --text: #FFFFFF;
+            --text-muted: #94A3B8;
+            --text-dim: #64748B;
+            --accent: #2EE5C5;
+            --accent-2: #38BDF8;
+            --accent-purple: #8B5CF6;
+            --accent-glow: rgba(46, 229, 197, 0.18);
+            --accent-glow-strong: rgba(46, 229, 197, 0.35);
+            --purple-glow: rgba(139, 92, 246, 0.16);
+            --font-sans: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            --font-mono: 'JetBrains Mono', 'SF Mono', Menlo, Consolas, monospace;
+            --ease: cubic-bezier(0.4, 0, 0.2, 1);
+        }
+
+        html {
+            scroll-behavior: smooth;
         }
 
         body {
-            font-family: -apple-system, BlinkMacSystemFont, 'SF Pro Display', 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
-            line-height: 1.6;
-            color: var(--text-primary);
-            background: #FFFFFF;
+            font-family: var(--font-sans);
+            line-height: 1.55;
+            color: var(--text);
+            background: var(--bg);
             overflow-x: hidden;
             -webkit-font-smoothing: antialiased;
             -moz-osx-font-smoothing: grayscale;
+            background-image:
+                radial-gradient(ellipse 1200px 800px at 18% -180px, var(--purple-glow), transparent 60%),
+                radial-gradient(ellipse 900px 600px at 90% 200px, rgba(46, 229, 197, 0.06), transparent 70%),
+                radial-gradient(ellipse 900px 600px at 50% 80%, rgba(56, 189, 248, 0.04), transparent 80%);
+            background-attachment: fixed;
+        }
+
+        /* Subtle dot grid texture overlay */
+        body::before {
+            content: "";
+            position: fixed;
+            inset: 0;
+            background-image: radial-gradient(circle at 1px 1px, rgba(255,255,255,0.025) 1px, transparent 0);
+            background-size: 32px 32px;
+            pointer-events: none;
+            z-index: 0;
+        }
+
+        body > * {
+            position: relative;
+            z-index: 1;
         }
 
         /* Navigation */
@@ -64,67 +98,70 @@ KEY CHANGES:
             top: 0;
             left: 0;
             right: 0;
-            background: rgba(255, 255, 255, 0.8);
-            backdrop-filter: blur(20px);
-            -webkit-backdrop-filter: blur(20px);
+            background: rgba(7, 8, 12, 0.7);
+            backdrop-filter: blur(20px) saturate(140%);
+            -webkit-backdrop-filter: blur(20px) saturate(140%);
             z-index: 1000;
-            transition: all 0.3s ease;
+            border-bottom: 1px solid var(--border);
+            transition: all 0.2s var(--ease);
         }
 
         .nav-container {
-            max-width: 95%;
+            max-width: 1280px;
             margin: 0 auto;
-            padding: 16px 24px;
+            padding: 14px 24px;
             display: flex;
             justify-content: space-between;
             align-items: center;
         }
 
         .logo {
-            font-size: 20px;
+            font-size: 17px;
             font-weight: 600;
             letter-spacing: -0.02em;
-            color: var(--text-primary);
+            color: var(--text);
             text-decoration: none;
-            transition: opacity 0.2s ease;
+            transition: opacity 0.2s var(--ease);
         }
 
         .logo:hover {
-            opacity: 0.7;
+            opacity: 0.85;
         }
 
         nav {
             display: flex;
             align-items: center;
-            gap: 32px;
+            gap: 28px;
         }
 
         nav a {
-            color: var(--text-primary);
+            color: var(--text-muted);
             text-decoration: none;
             font-size: 14px;
-            font-weight: 600;
+            font-weight: 500;
             letter-spacing: -0.01em;
-            transition: color 0.2s ease;
-            position: relative;
+            transition: color 0.2s var(--ease);
         }
 
         nav a:hover {
-            color: var(--accent);
+            color: var(--text);
         }
 
         .nav-cta {
-            background: var(--accent);
-            color: white !important;
-            padding: 10px 24px;
-            border-radius: 100px;
+            background: var(--text) !important;
+            color: var(--bg) !important;
+            padding: 9px 18px;
+            border-radius: 8px;
             font-size: 14px;
-            transition: all 0.2s ease;
+            font-weight: 600;
+            border: 1px solid var(--text);
+            transition: all 0.2s var(--ease);
         }
 
         .nav-cta:hover {
-            background: var(--accent-dark);
-            transform: translateY(-1px);
+            background: var(--accent) !important;
+            border-color: var(--accent) !important;
+            box-shadow: 0 0 24px var(--accent-glow);
         }
 
         /* Hero Section */
@@ -133,9 +170,10 @@ KEY CHANGES:
             display: flex;
             align-items: center;
             justify-content: center;
-            background: #000;
+            background: var(--bg);
             position: relative;
             overflow: hidden;
+            padding-top: 80px;
         }
 
         .video-background {
@@ -158,20 +196,22 @@ KEY CHANGES:
             left: 50%;
             transform: translate(-50%, -50%);
             object-fit: cover;
+            opacity: 0.32;
+            filter: saturate(0.6) contrast(1.15) brightness(0.9);
         }
 
         .video-overlay {
             position: absolute;
-            top: 0;
-            left: 0;
-            width: 100%;
-            height: 100%;
-            background: rgba(0, 0, 0, 0.45);
+            inset: 0;
+            background:
+                radial-gradient(ellipse 60% 70% at 50% 45%, transparent, rgba(7,8,12,0.85) 95%),
+                radial-gradient(circle 700px at 50% 30%, var(--accent-glow), transparent 70%),
+                linear-gradient(180deg, rgba(7,8,12,0.4) 0%, transparent 30%, transparent 70%, var(--bg) 100%);
             z-index: 1;
         }
 
         .hero-content {
-            max-width: 95%;
+            max-width: 1100px;
             margin: 0 auto;
             padding: 64px 24px;
             text-align: center;
@@ -182,266 +222,374 @@ KEY CHANGES:
             align-items: center;
         }
 
-        .hero-label {
-            display: inline-block;
-            background: rgba(255, 255, 255, 0.95);
-            color: var(--text-primary);
-            padding: 8px 20px;
+        .hero-badge {
+            display: inline-flex;
+            align-items: center;
+            gap: 10px;
+            background: rgba(255, 255, 255, 0.04);
+            border: 1px solid var(--border-strong);
+            color: var(--text-muted);
+            padding: 7px 16px;
             border-radius: 100px;
-            font-size: 13px;
+            font-family: var(--font-mono);
+            font-size: 12px;
             font-weight: 500;
-            letter-spacing: 0.5px;
-            text-transform: uppercase;
+            letter-spacing: 0.02em;
             margin-bottom: 32px;
-            border: 1px solid rgba(255, 255, 255, 0.3);
-            animation: fadeInUp 0.8s ease;
             backdrop-filter: blur(10px);
+            box-shadow:
+                inset 0 0 0 1px rgba(46, 229, 197, 0.05),
+                0 0 32px rgba(46, 229, 197, 0.08);
+            animation: fadeInUp 0.6s ease;
+        }
+
+        .hero-badge-dot {
+            width: 6px;
+            height: 6px;
+            border-radius: 50%;
+            background: var(--accent);
+            box-shadow: 0 0 10px var(--accent), 0 0 20px var(--accent-glow);
+            animation: pulse 2s infinite ease-in-out;
+        }
+
+        @keyframes pulse {
+            0%, 100% { opacity: 1; transform: scale(1); }
+            50% { opacity: 0.55; transform: scale(0.85); }
         }
 
         .hero h1 {
-            font-size: clamp(48px, 8vw, 96px);
+            font-size: clamp(44px, 7.5vw, 92px);
             font-weight: 700;
-            line-height: 0.95;
-            letter-spacing: -0.04em;
-            color: white;
-            margin-bottom: 24px;
-            animation: fadeInUp 0.8s ease 0.1s both;
-            text-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
+            line-height: 1.0;
+            letter-spacing: -0.045em;
+            color: var(--text);
+            margin-bottom: 28px;
+            animation: fadeInUp 0.7s ease 0.1s both;
+            max-width: 980px;
         }
 
         .hero h1 .gradient-text {
-            background: linear-gradient(135deg, #4A90E2 0%, #7B68EE 100%);
+            background: linear-gradient(135deg, var(--accent) 0%, var(--accent-2) 60%, var(--accent-purple) 100%);
             -webkit-background-clip: text;
             -webkit-text-fill-color: transparent;
             background-clip: text;
         }
 
         .hero-description {
-            font-size: 20px;
-            line-height: 1.4;
-            color: rgba(255, 255, 255, 0.9);
-            max-width: 680px;
+            font-size: clamp(16px, 1.6vw, 19px);
+            line-height: 1.55;
+            color: var(--text-muted);
+            max-width: 660px;
             text-align: center;
-            margin: 0 auto 48px;
-            animation: fadeInUp 0.8s ease 0.2s both;
-            text-shadow: 0 1px 2px rgba(0, 0, 0, 0.3);
+            margin: 0 auto 44px;
+            animation: fadeInUp 0.7s ease 0.2s both;
         }
 
         .hero-actions {
             display: flex;
-            gap: 20px;
+            gap: 12px;
             justify-content: center;
-            animation: fadeInUp 0.8s ease 0.3s both;
+            animation: fadeInUp 0.7s ease 0.3s both;
+            flex-wrap: wrap;
         }
 
+        /* Buttons */
         .btn-primary {
-            background: var(--accent);
-            color: white;
-            padding: 16px 32px;
+            background: var(--text);
+            color: var(--bg);
+            padding: 13px 24px;
             text-decoration: none;
-            border-radius: 100px;
+            border-radius: 8px;
             font-weight: 600;
-            font-size: 16px;
-            transition: all 0.2s ease;
+            font-size: 15px;
+            letter-spacing: -0.01em;
+            transition: all 0.2s var(--ease);
             display: inline-flex;
             align-items: center;
             gap: 8px;
+            border: 1px solid var(--text);
         }
 
         .btn-primary:hover {
-            background: var(--accent-dark);
-            transform: translateY(-2px);
+            background: var(--accent);
+            color: var(--bg);
+            border-color: var(--accent);
+            box-shadow: 0 0 32px var(--accent-glow), 0 8px 24px rgba(0,0,0,0.4);
+            transform: translateY(-1px);
         }
 
         .btn-secondary {
-            background: rgba(255, 255, 255, 0.95);
-            color: var(--text-primary);
-            padding: 16px 32px;
+            background: rgba(255, 255, 255, 0.02);
+            color: var(--text);
+            padding: 13px 24px;
             text-decoration: none;
-            border-radius: 100px;
-            font-weight: 600;
-            font-size: 16px;
+            border-radius: 8px;
+            font-weight: 500;
+            font-size: 15px;
+            letter-spacing: -0.01em;
             display: inline-flex;
             align-items: center;
-            transition: all 0.2s ease;
-            border: 1px solid rgba(255, 255, 255, 0.3);
-            backdrop-filter: blur(10px);
+            gap: 8px;
+            transition: all 0.2s var(--ease);
+            border: 1px solid var(--border-strong);
+            backdrop-filter: blur(8px);
         }
 
         .btn-secondary:hover {
-            background: white;
-            transform: translateY(-2px);
+            border-color: rgba(46, 229, 197, 0.5);
+            color: var(--accent);
+            box-shadow: inset 0 0 0 1px rgba(46, 229, 197, 0.15);
+        }
+
+        .btn-light {
+            background: var(--accent);
+            color: var(--bg);
+            padding: 13px 24px;
+            text-decoration: none;
+            border-radius: 8px;
+            font-weight: 600;
+            font-size: 15px;
+            transition: all 0.2s var(--ease);
+            display: inline-flex;
+            align-items: center;
+            gap: 8px;
+            border: 1px solid var(--accent);
+        }
+
+        .btn-light:hover {
+            background: var(--text);
+            color: var(--bg);
+            border-color: var(--text);
+            box-shadow: 0 0 32px var(--accent-glow);
+            transform: translateY(-1px);
+        }
+
+        .btn-ghost {
+            background: transparent;
+            color: var(--text);
+            padding: 13px 24px;
+            text-decoration: none;
+            border-radius: 8px;
+            font-weight: 500;
+            font-size: 15px;
+            transition: all 0.2s var(--ease);
+            display: inline-flex;
+            align-items: center;
+            gap: 8px;
+            border: 1px solid var(--border-strong);
+        }
+
+        .btn-ghost:hover {
+            border-color: var(--accent);
+            color: var(--accent);
         }
 
         .btn-outline {
             background: transparent;
             color: var(--accent);
-            padding: 14px 28px;
+            padding: 13px 24px;
             text-decoration: none;
-            border-radius: 100px;
-            font-weight: 600;
+            border-radius: 8px;
+            font-weight: 500;
             font-size: 15px;
-            transition: all 0.2s ease;
+            transition: all 0.2s var(--ease);
             display: inline-flex;
             align-items: center;
             gap: 8px;
-            border: 2px solid var(--accent);
+            border: 1px solid var(--accent);
         }
 
         .btn-outline:hover {
             background: var(--accent);
-            color: white;
-            transform: translateY(-2px);
+            color: var(--bg);
         }
 
-        /* Section Styling */
+        /* Sections */
         .section {
-            padding: 80px 24px;
+            padding: 100px 24px;
+            position: relative;
         }
 
         .section-header {
-            max-width: 800px;
-            margin: 0 auto 60px;
+            max-width: 1280px;
+            margin: 0 auto 56px;
+            text-align: left;
         }
 
         .section-label {
-            font-size: 13px;
+            display: inline-flex;
+            align-items: center;
+            gap: 8px;
+            font-family: var(--font-mono);
+            font-size: 12px;
             font-weight: 500;
-            letter-spacing: 0.5px;
+            letter-spacing: 0.05em;
             text-transform: uppercase;
-            color: var(--text-tertiary);
-            margin-bottom: 16px;
+            color: var(--accent);
+            margin-bottom: 18px;
+        }
+
+        .section-label::before {
+            content: "";
+            width: 6px;
+            height: 6px;
+            border-radius: 50%;
+            background: var(--accent);
+            box-shadow: 0 0 10px var(--accent), 0 0 16px var(--accent-glow);
         }
 
         .section h2 {
-            font-size: clamp(36px, 5vw, 56px);
-            font-weight: 700;
-            line-height: 1.1;
-            letter-spacing: -0.03em;
-            color: var(--accent);
-            margin-bottom: 24px;
+            font-size: clamp(34px, 4.5vw, 58px);
+            font-weight: 600;
+            line-height: 1.05;
+            letter-spacing: -0.035em;
+            color: var(--text);
+            margin-bottom: 22px;
+            max-width: 820px;
         }
 
         .section-description {
-            font-size: 20px;
-            line-height: 1.5;
-            color: var(--text-secondary);
-            max-width: 720px;
+            font-size: clamp(15px, 1.4vw, 18px);
+            line-height: 1.6;
+            color: var(--text-muted);
+            max-width: 760px;
+        }
+
+        .section-description strong {
+            color: var(--text);
+            font-weight: 600;
+        }
+
+        /* Override inline secondary backgrounds — everything is dark now */
+        .section[style*="secondary"] {
+            background: transparent !important;
         }
 
         /* Programs Section */
         .programs-container {
-            max-width: 1200px;
+            max-width: 1280px;
             margin: 0 auto;
-        }
-
-        .track-header {
-            margin-bottom: 40px;
-            padding-bottom: 20px;
-            border-bottom: 1px solid var(--border);
-        }
-
-        .track-header h3 {
-            font-size: 28px;
-            font-weight: 700;
-            color: var(--text-primary);
-            margin-bottom: 8px;
-        }
-
-        .track-header p {
-            font-size: 16px;
-            color: var(--text-secondary);
         }
 
         .grade-grid {
             display: grid;
             grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
-            gap: 24px;
-            margin-bottom: 80px;
+            gap: 16px;
+            margin-bottom: 0;
         }
 
         .grade-card {
-            background: white;
+            background: var(--surface);
             border: 1px solid var(--border);
-            border-radius: 16px;
-            padding: 32px;
-            transition: all 0.3s ease;
+            border-radius: 12px;
+            padding: 28px;
+            transition: all 0.25s var(--ease);
+            position: relative;
+            overflow: hidden;
         }
 
-        .grade-section-build {
-            min-height: 180px;
-        }
-
-        .grade-section-offer {
-            min-height: 220px;
+        .grade-card::after {
+            content: "";
+            position: absolute;
+            top: -150px;
+            right: -150px;
+            width: 300px;
+            height: 300px;
+            background: radial-gradient(circle, var(--accent-glow), transparent 70%);
+            opacity: 0;
+            transition: opacity 0.3s var(--ease);
+            pointer-events: none;
         }
 
         .grade-card:hover {
-            transform: translateY(-4px);
-            box-shadow: 0 12px 24px rgba(0, 0, 0, 0.08);
-            border-color: var(--accent);
+            background: var(--surface-hover);
+            border-color: var(--border-strong);
+            transform: translateY(-2px);
+        }
+
+        .grade-card:hover::after {
+            opacity: 0.6;
+        }
+
+        .grade-section-build,
+        .grade-section-offer {
+            min-height: 180px;
         }
 
         .grade-card-header {
             display: flex;
             align-items: center;
-            gap: 16px;
-            margin-bottom: 24px;
+            gap: 14px;
+            margin-bottom: 22px;
+            position: relative;
         }
 
         .grade-icon {
-            width: 56px;
-            height: 56px;
-            background: var(--accent);
-            color: white;
-            border-radius: 12px;
+            width: 44px;
+            height: 44px;
+            background: rgba(46, 229, 197, 0.08);
+            color: var(--accent);
+            border: 1px solid rgba(46, 229, 197, 0.2);
+            border-radius: 8px;
             display: flex;
             align-items: center;
             justify-content: center;
-            font-size: 16px;
-            font-weight: 700;
+            font-family: var(--font-mono);
+            font-size: 13px;
+            font-weight: 600;
             letter-spacing: -0.02em;
         }
 
         .grade-card h4 {
-            font-size: 22px;
+            font-size: 20px;
             font-weight: 600;
-            color: var(--text-primary);
+            color: var(--text);
             margin-bottom: 4px;
+            letter-spacing: -0.02em;
         }
 
         .grade-badge {
-            font-size: 13px;
-            color: var(--text-tertiary);
+            font-family: var(--font-mono);
+            font-size: 11px;
+            color: var(--text-dim);
             font-weight: 500;
+            letter-spacing: 0.04em;
+            text-transform: uppercase;
         }
 
         .grade-details {
             display: flex;
-            gap: 16px;
+            gap: 8px;
             margin-bottom: 20px;
             flex-wrap: wrap;
+            position: relative;
         }
 
         .grade-detail {
-            font-size: 13px;
-            color: var(--text-secondary);
-            background: var(--secondary);
-            padding: 6px 12px;
-            border-radius: 20px;
+            font-family: var(--font-mono);
+            font-size: 11px;
+            color: var(--text-muted);
+            background: rgba(255, 255, 255, 0.025);
+            border: 1px solid var(--border);
+            padding: 4px 10px;
+            border-radius: 4px;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
         }
 
         .grade-section {
             margin-bottom: 20px;
+            position: relative;
         }
 
         .grade-section-title {
-            font-size: 13px;
-            font-weight: 600;
+            font-family: var(--font-mono);
+            font-size: 11px;
+            font-weight: 500;
             text-transform: uppercase;
-            letter-spacing: 0.5px;
-            color: var(--text-tertiary);
-            margin-bottom: 10px;
+            letter-spacing: 0.05em;
+            color: var(--text-dim);
+            margin-bottom: 12px;
         }
 
         .grade-section ul {
@@ -450,254 +598,253 @@ KEY CHANGES:
         }
 
         .grade-section li {
-            font-size: 15px;
-            color: var(--text-secondary);
-            padding: 6px 0;
+            font-size: 14px;
+            color: var(--text-muted);
+            padding: 5px 0;
             display: flex;
             align-items: baseline;
             gap: 10px;
+            line-height: 1.55;
         }
 
         .grade-section li::before {
             content: "";
-            width: 6px;
-            height: 6px;
+            width: 4px;
+            height: 4px;
             background: var(--accent);
             border-radius: 50%;
             flex-shrink: 0;
             position: relative;
             top: -2px;
+            box-shadow: 0 0 6px var(--accent-glow);
         }
 
         .grade-fit {
-            background: var(--hover);
-            padding: 16px;
-            border-radius: 12px;
+            background: rgba(46, 229, 197, 0.04);
+            border: 1px solid rgba(46, 229, 197, 0.15);
+            padding: 14px;
+            border-radius: 8px;
             margin-top: 20px;
         }
 
         .grade-fit-title {
-            font-size: 14px;
-            font-weight: 600;
-            color: var(--text-primary);
+            font-family: var(--font-mono);
+            font-size: 12px;
+            font-weight: 500;
+            color: var(--accent);
             margin-bottom: 8px;
+            letter-spacing: 0.03em;
+            text-transform: uppercase;
         }
 
         .grade-fit p {
             font-size: 14px;
-            color: var(--text-secondary);
-            line-height: 1.5;
+            color: var(--text-muted);
+            line-height: 1.55;
         }
 
-        /* Competition Team Cards */
+        /* Competition Grid (bento) */
         .competition-grid {
             display: grid;
             grid-template-columns: repeat(2, 1fr);
-            gap: 0;
-            max-width: 1200px;
-            margin: 0 auto 40px;
+            gap: 1px;
+            max-width: 1280px;
+            margin: 0 auto 32px;
+            background: var(--border);
+            border: 1px solid var(--border);
+            border-radius: 12px;
+            overflow: hidden;
         }
 
         .competition-block {
-            background: white;
-            border: 1px solid var(--border);
-            padding: 48px 32px;
-            transition: background 0.3s ease;
+            background: var(--surface);
+            padding: 36px 32px;
+            transition: background 0.25s var(--ease);
         }
 
         .competition-block:hover {
-            background: var(--hover);
+            background: var(--surface-hover);
         }
 
         .competition-block h4 {
-            font-size: 20px;
+            font-size: 18px;
             font-weight: 600;
-            color: var(--text-primary);
+            color: var(--text);
             margin-bottom: 12px;
+            letter-spacing: -0.02em;
         }
 
         .competition-block p {
-            font-size: 16px;
-            color: var(--text-secondary);
+            font-size: 15px;
+            color: var(--text-muted);
             line-height: 1.6;
         }
 
         .competition-goals {
-            background: white;
+            background: var(--surface);
             border: 1px solid var(--border);
-            padding: 48px 32px;
-            max-width: 1200px;
+            padding: 32px;
+            border-radius: 12px;
+            max-width: 1280px;
             margin: 0 auto 32px;
         }
 
         .competition-goals h4 {
-            font-size: 16px;
-            font-weight: 600;
-            color: #10B981;
+            font-family: var(--font-mono);
+            font-size: 12px;
+            font-weight: 500;
+            color: var(--accent);
             margin-bottom: 12px;
+            text-transform: uppercase;
+            letter-spacing: 0.04em;
         }
 
         .competition-goals p {
             font-size: 15px;
-            color: var(--text-secondary);
-            line-height: 1.8;
+            color: var(--text-muted);
+            line-height: 1.65;
         }
 
         .competition-actions {
             display: flex;
             justify-content: center;
-            max-width: 1200px;
+            max-width: 1280px;
             margin: 0 auto;
         }
 
-        .btn-light {
-            background: var(--accent);
-            color: white;
-            padding: 14px 28px;
-            text-decoration: none;
-            border-radius: 100px;
-            font-weight: 600;
-            font-size: 15px;
-            transition: all 0.2s ease;
-            display: inline-flex;
-            align-items: center;
-            gap: 8px;
-        }
-
-        .btn-light:hover {
-            transform: translateY(-2px);
-            box-shadow: 0 8px 24px rgba(99, 102, 241, 0.3);
-            background: var(--accent-dark);
-        }
-
-        .btn-ghost {
-            background: transparent;
-            color: var(--accent);
-            padding: 14px 28px;
-            text-decoration: none;
-            border-radius: 100px;
-            font-weight: 600;
-            font-size: 15px;
-            transition: all 0.2s ease;
-            display: inline-flex;
-            align-items: center;
-            gap: 8px;
-            border: 2px solid var(--border);
-        }
-
-        .btn-ghost:hover {
-            background: var(--secondary);
-            border-color: var(--accent);
-        }
-
-        /* Learning Approach Section */
+        /* Learning Approach (bento) */
         .approach-grid {
             display: grid;
             grid-template-columns: repeat(3, 1fr);
-            gap: 0;
-            max-width: 1200px;
-            margin: 0 auto 60px;
+            gap: 1px;
+            max-width: 1280px;
+            margin: 0 auto 32px;
+            background: var(--border);
+            border: 1px solid var(--border);
+            border-radius: 12px;
+            overflow: hidden;
         }
 
         .approach-card {
-            background: white;
-            border: 1px solid var(--border);
-            padding: 48px 32px;
-            transition: background 0.3s ease;
+            background: var(--surface);
+            padding: 36px 32px;
+            transition: background 0.25s var(--ease);
+            position: relative;
         }
 
         .approach-card:hover {
-            background: var(--hover);
+            background: var(--surface-hover);
         }
 
         .approach-card h4 {
-            font-size: 20px;
+            font-size: 18px;
             font-weight: 600;
-            color: var(--text-primary);
+            color: var(--text);
             margin-bottom: 12px;
+            letter-spacing: -0.02em;
         }
 
         .approach-card p {
-            font-size: 16px;
+            font-size: 15px;
             line-height: 1.6;
-            color: var(--text-secondary);
+            color: var(--text-muted);
         }
 
-        /* Progress Tracking Subsection */
+        /* Progress section card */
         .progress-section {
-            max-width: 900px;
-            margin: 0 auto;
-            background: var(--hover);
-            border-radius: 20px;
+            max-width: 1280px;
+            margin: 32px auto 0;
+            background: var(--surface);
+            border: 1px solid var(--border);
+            border-radius: 16px;
             padding: 48px;
+            position: relative;
+            overflow: hidden;
+        }
+
+        .progress-section::before {
+            content: "";
+            position: absolute;
+            top: -200px;
+            right: -200px;
+            width: 500px;
+            height: 500px;
+            background: radial-gradient(circle, var(--accent-glow), transparent 70%);
+            pointer-events: none;
+            opacity: 0.6;
         }
 
         .progress-section h3 {
-            font-size: 28px;
-            font-weight: 700;
-            color: var(--text-primary);
-            margin-bottom: 24px;
-            text-align: center;
+            font-size: 24px;
+            font-weight: 600;
+            color: var(--text);
+            margin-bottom: 32px;
+            text-align: left;
+            letter-spacing: -0.025em;
+            position: relative;
         }
 
         .progress-grid {
             display: grid;
-            grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+            grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
             gap: 32px;
+            position: relative;
         }
 
         .progress-item h4 {
-            font-size: 16px;
+            font-size: 15px;
             font-weight: 600;
-            color: var(--text-primary);
-            margin-bottom: 12px;
-            display: flex;
-            align-items: center;
-            gap: 8px;
+            color: var(--text);
+            margin-bottom: 10px;
+            letter-spacing: -0.01em;
         }
 
         .progress-item p {
-            font-size: 15px;
+            font-size: 14px;
             line-height: 1.6;
-            color: var(--text-secondary);
+            color: var(--text-muted);
         }
 
-        /* Outcomes Section */
+        /* Outcomes (bento) */
         .outcomes-grid {
             display: grid;
             grid-template-columns: repeat(3, 1fr);
-            gap: 0;
-            max-width: 1200px;
+            gap: 1px;
+            max-width: 1280px;
             margin: 0 auto;
+            background: var(--border);
+            border: 1px solid var(--border);
+            border-radius: 12px;
+            overflow: hidden;
         }
 
         .outcome-item {
-            background: white;
-            border: 1px solid var(--border);
-            padding: 48px 32px;
-            transition: background 0.3s ease;
+            background: var(--surface);
+            padding: 36px 32px;
+            transition: background 0.25s var(--ease);
         }
 
         .outcome-item:hover {
-            background: var(--hover);
+            background: var(--surface-hover);
         }
 
         .outcome-item h4 {
-            font-size: 20px;
+            font-size: 18px;
             font-weight: 600;
-            color: var(--text-primary);
-            margin-bottom: 12px;
+            color: var(--text);
+            margin-bottom: 10px;
+            letter-spacing: -0.02em;
         }
 
         .outcome-item p {
-            font-size: 16px;
+            font-size: 15px;
             line-height: 1.6;
-            color: var(--text-secondary);
+            color: var(--text-muted);
         }
 
         .showcase-section {
-            max-width: 1000px;
-            margin: 0 auto;
+            max-width: 1280px;
+            margin: 32px auto 0;
         }
 
         .showcase-header {
@@ -706,168 +853,208 @@ KEY CHANGES:
         }
 
         .showcase-header h3 {
-            font-size: 24px;
+            font-size: 22px;
             font-weight: 600;
-            color: var(--text-primary);
+            color: var(--text);
             margin-bottom: 8px;
+            letter-spacing: -0.02em;
         }
 
         .showcase-header p {
-            font-size: 15px;
-            color: var(--text-tertiary);
+            font-size: 14px;
+            color: var(--text-dim);
         }
 
         .showcase-grid {
             display: grid;
             grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-            gap: 16px;
+            gap: 12px;
         }
 
         .showcase-card {
-            background: var(--secondary);
+            background: var(--surface);
+            border: 1px solid var(--border);
             border-radius: 12px;
-            padding: 32px 24px;
+            padding: 24px;
             text-align: center;
-            transition: all 0.2s ease;
+            transition: all 0.25s var(--ease);
         }
 
         .showcase-card:hover {
-            transform: translateY(-4px);
-            background: var(--hover);
+            transform: translateY(-2px);
+            background: var(--surface-hover);
+            border-color: var(--border-strong);
         }
 
         .showcase-card-icon {
-            width: 48px;
-            height: 48px;
-            background: var(--accent);
-            color: white;
-            border-radius: 12px;
+            width: 44px;
+            height: 44px;
+            background: rgba(46, 229, 197, 0.08);
+            color: var(--accent);
+            border: 1px solid rgba(46, 229, 197, 0.2);
+            border-radius: 8px;
             display: flex;
             align-items: center;
             justify-content: center;
-            font-size: 16px;
-            font-weight: 700;
-            margin: 0 auto 16px;
+            font-family: var(--font-mono);
+            font-size: 13px;
+            font-weight: 600;
+            margin: 0 auto 14px;
         }
 
         .showcase-card h4 {
-            font-size: 15px;
-            font-weight: 600;
-            color: var(--text-primary);
+            font-size: 14px;
+            font-weight: 500;
+            color: var(--text);
         }
 
-        /* About/Team Section */
+        /* About / Team */
         .credentials-showcase {
-            max-width: 1100px;
+            max-width: 1280px;
             margin: 0 auto;
         }
 
         .company-text-bar {
             text-align: center;
-            margin-bottom: 48px;
-            padding: 40px 24px;
-            background: white;
-            border-radius: 16px;
+            margin-bottom: 16px;
+            padding: 36px 24px 28px;
+            background: var(--surface);
+            border-radius: 12px;
             border: 1px solid var(--border);
+            position: relative;
+            overflow: hidden;
+        }
+
+        .company-text-bar::before {
+            content: "RESEARCH ROOTS · INDUSTRY EXPERIENCE";
+            display: block;
+            font-family: var(--font-mono);
+            font-size: 10px;
+            letter-spacing: 0.18em;
+            color: var(--text-dim);
+            text-transform: uppercase;
+            margin-bottom: 22px;
         }
 
         .company-names {
-            display: grid;
-            grid-template-columns: repeat(4, 1fr);
-            gap: 24px;
-            justify-items: center;
+            display: flex;
+            flex-wrap: wrap;
+            justify-content: center;
             align-items: center;
-            max-width: 900px;
+            gap: 40px;
+            max-width: 1100px;
             margin: 0 auto;
         }
 
         .company-logo {
-            height: 80px;
-            max-width: 100%;
+            max-height: 28px !important;
+            height: auto !important;
+            max-width: 120px;
             object-fit: contain;
-            opacity: 0.8;
-            transition: all 0.2s ease;
+            opacity: 0.55;
+            filter: brightness(0) invert(1);
+            transition: opacity 0.2s var(--ease);
         }
 
         .company-logo:hover {
             opacity: 1;
-            transform: scale(1.05);
         }
 
         .credentials-grid {
             display: grid;
             grid-template-columns: repeat(2, 1fr);
-            gap: 0;
-            margin-bottom: 0;
+            gap: 1px;
+            background: var(--border);
+            border: 1px solid var(--border);
+            border-radius: 12px;
+            overflow: hidden;
+            margin-bottom: 16px;
         }
 
         .credential-card {
-            background: white;
-            padding: 48px 32px;
-            border: 1px solid var(--border);
-            transition: background 0.3s ease;
+            background: var(--surface);
+            padding: 32px;
+            transition: background 0.25s var(--ease);
         }
 
         .credential-card:hover {
-            background: var(--hover);
+            background: var(--surface-hover);
         }
 
         .credential-card h4 {
-            font-size: 20px;
+            font-size: 17px;
             font-weight: 600;
-            color: var(--text-primary);
-            margin-bottom: 12px;
+            color: var(--text);
+            margin-bottom: 10px;
+            letter-spacing: -0.02em;
         }
 
         .credential-card p {
-            font-size: 16px;
+            font-size: 14px;
             line-height: 1.6;
-            color: var(--text-secondary);
+            color: var(--text-muted);
         }
 
         .team-values {
             display: grid;
             grid-template-columns: repeat(3, 1fr);
-            gap: 0;
+            gap: 1px;
+            background: var(--border);
+            border: 1px solid var(--border);
+            border-radius: 12px;
+            overflow: hidden;
         }
 
         .team-value {
-            background: white;
-            padding: 48px 32px;
-            border: 1px solid var(--border);
-            transition: background 0.3s ease;
+            background: var(--surface);
+            padding: 32px;
+            transition: background 0.25s var(--ease);
         }
 
         .team-value:hover {
-            background: var(--hover);
+            background: var(--surface-hover);
         }
 
         .team-value h4 {
-            font-size: 20px;
+            font-size: 16px;
             font-weight: 600;
-            color: var(--text-primary);
-            margin-bottom: 12px;
+            color: var(--text);
+            margin-bottom: 10px;
+            letter-spacing: -0.02em;
         }
 
         .team-value p {
-            font-size: 16px;
+            font-size: 14px;
             line-height: 1.6;
-            color: var(--text-secondary);
+            color: var(--text-muted);
         }
 
-        /* FAQ Section */
+        /* FAQ */
         .faq-container {
-            max-width: 800px;
+            max-width: 880px;
             margin: 0 auto;
+            background: var(--surface);
+            border: 1px solid var(--border);
+            border-radius: 12px;
+            overflow: hidden;
         }
 
         .faq-item {
             border-bottom: 1px solid var(--border);
+            transition: background 0.2s var(--ease);
+        }
+
+        .faq-item:last-child {
+            border-bottom: none;
+        }
+
+        .faq-item:hover {
+            background: rgba(255, 255, 255, 0.015);
         }
 
         .faq-question {
             width: 100%;
-            padding: 24px 0;
+            padding: 22px 28px;
             background: none;
             border: none;
             text-align: left;
@@ -875,10 +1062,13 @@ KEY CHANGES:
             display: flex;
             justify-content: space-between;
             align-items: center;
-            font-size: 17px;
-            font-weight: 600;
-            color: var(--text-primary);
-            font-family: inherit;
+            gap: 16px;
+            font-size: 15px;
+            font-weight: 500;
+            color: var(--text);
+            font-family: var(--font-sans);
+            transition: color 0.2s var(--ease);
+            letter-spacing: -0.01em;
         }
 
         .faq-question:hover {
@@ -886,64 +1076,91 @@ KEY CHANGES:
         }
 
         .faq-icon {
-            font-size: 24px;
-            transition: transform 0.3s ease;
-            color: var(--text-tertiary);
+            font-size: 20px;
+            transition: transform 0.25s var(--ease), color 0.2s var(--ease);
+            color: var(--text-dim);
+            font-weight: 300;
+            flex-shrink: 0;
         }
 
         .faq-item.active .faq-icon {
             transform: rotate(45deg);
+            color: var(--accent);
         }
 
         .faq-answer {
             max-height: 0;
             overflow: hidden;
-            transition: max-height 0.3s ease, padding 0.3s ease;
+            transition: max-height 0.3s var(--ease), padding 0.3s ease;
+            padding: 0 28px;
         }
 
         .faq-item.active .faq-answer {
             max-height: 500px;
-            padding-bottom: 24px;
+            padding: 0 28px 22px;
         }
 
         .faq-answer p {
-            font-size: 16px;
+            font-size: 14px;
             line-height: 1.7;
-            color: var(--text-secondary);
+            color: var(--text-muted);
         }
 
-        /* Registration Section */
+        /* Registration */
         .registration-form {
-            max-width: 600px;
+            max-width: 640px;
             margin: 0 auto;
-            background: white;
+            background: var(--surface);
             padding: 40px;
             border-radius: 16px;
-            box-shadow: 0 4px 24px rgba(0, 0, 0, 0.04);
+            border: 1px solid var(--border);
+            position: relative;
+            overflow: hidden;
+        }
+
+        .registration-form::before {
+            content: "";
+            position: absolute;
+            top: -200px;
+            left: -200px;
+            width: 500px;
+            height: 500px;
+            background: radial-gradient(circle, var(--accent-glow), transparent 70%);
+            pointer-events: none;
+            opacity: 0.5;
         }
 
         .form-group {
-            margin-bottom: 24px;
+            margin-bottom: 20px;
+            position: relative;
         }
 
         .form-group label {
             display: block;
             margin-bottom: 8px;
-            color: var(--text-primary);
+            color: var(--text);
             font-weight: 500;
-            font-size: 15px;
+            font-size: 13px;
+            letter-spacing: -0.01em;
         }
 
         .form-group input,
         .form-group select,
         .form-group textarea {
             width: 100%;
-            padding: 14px;
-            border: 1px solid var(--border);
+            padding: 12px 14px;
+            background: rgba(255, 255, 255, 0.025);
+            border: 1px solid var(--border-strong);
             border-radius: 8px;
-            font-size: 16px;
-            font-family: inherit;
-            transition: border-color 0.2s ease;
+            font-size: 14px;
+            font-family: var(--font-sans);
+            color: var(--text);
+            transition: all 0.2s var(--ease);
+        }
+
+        .form-group input::placeholder,
+        .form-group textarea::placeholder {
+            color: var(--text-dim);
         }
 
         .form-group input:focus,
@@ -951,92 +1168,123 @@ KEY CHANGES:
         .form-group textarea:focus {
             outline: none;
             border-color: var(--accent);
+            background: rgba(46, 229, 197, 0.04);
+            box-shadow: 0 0 0 3px rgba(46, 229, 197, 0.1);
         }
 
         .form-group select {
             appearance: none;
-            background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12'%3E%3Cpath fill='%23666' d='M6 8L1 3h10z'/%3E%3C/svg%3E");
+            background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12'%3E%3Cpath fill='%2394A3B8' d='M6 8L1 3h10z'/%3E%3C/svg%3E");
             background-repeat: no-repeat;
             background-position: right 14px center;
             padding-right: 40px;
         }
 
+        .form-group select option,
+        .form-group select optgroup {
+            background: var(--surface);
+            color: var(--text);
+        }
+
         .form-submit {
             background: var(--accent);
-            color: white;
-            padding: 16px 40px;
-            border: none;
-            border-radius: 100px;
-            font-size: 16px;
+            color: var(--bg);
+            padding: 14px 32px;
+            border: 1px solid var(--accent);
+            border-radius: 8px;
+            font-size: 15px;
             font-weight: 600;
+            font-family: var(--font-sans);
             cursor: pointer;
             width: 100%;
-            transition: all 0.2s ease;
+            transition: all 0.2s var(--ease);
+            letter-spacing: -0.01em;
         }
 
         .form-submit:hover {
-            background: var(--accent-dark);
+            background: var(--text);
+            color: var(--bg);
+            border-color: var(--text);
+            box-shadow: 0 0 32px var(--accent-glow);
         }
 
         .schedule-note {
             text-align: center;
-            margin-top: 24px;
-            font-size: 14px;
-            color: var(--text-tertiary);
+            margin-top: 22px;
+            font-size: 13px;
+            color: var(--text-dim);
+            font-family: var(--font-mono);
+            position: relative;
         }
 
-        /* Story Section */
+        /* Team Story */
         .team-story-container {
             display: grid;
             grid-template-columns: 1fr 1fr;
             grid-template-rows: 1fr 1fr;
-            gap: 24px;
-            max-width: 1100px;
+            gap: 16px;
+            max-width: 1280px;
             margin: 0 auto;
         }
 
         .team-story {
             grid-column: 2 / 3;
             grid-row: 1 / 2;
-            padding: 40px;
-            background: white;
-            border-radius: 16px;
+            padding: 36px;
+            background: var(--surface);
+            border-radius: 12px;
             border: 1px solid var(--border);
         }
 
         .team-story-label {
-            font-size: 13px;
+            display: inline-flex;
+            align-items: center;
+            gap: 8px;
+            font-family: var(--font-mono);
+            font-size: 11px;
             font-weight: 500;
-            letter-spacing: 0.5px;
+            letter-spacing: 0.06em;
             text-transform: uppercase;
-            color: var(--text-tertiary);
+            color: var(--accent);
             margin-bottom: 16px;
+        }
+
+        .team-story-label::before {
+            content: "";
+            width: 5px;
+            height: 5px;
+            border-radius: 50%;
+            background: var(--accent);
+            box-shadow: 0 0 8px var(--accent-glow);
         }
 
         .team-story h3 {
-            font-size: clamp(28px, 4vw, 36px);
-            font-weight: 700;
-            line-height: 1.2;
-            letter-spacing: -0.02em;
-            color: var(--accent);
-            margin-bottom: 20px;
+            font-size: clamp(24px, 3vw, 32px);
+            font-weight: 600;
+            line-height: 1.15;
+            letter-spacing: -0.025em;
+            color: var(--text);
+            margin-bottom: 18px;
         }
 
         .team-story-description {
-            font-size: 16px;
-            line-height: 1.6;
-            color: var(--text-secondary);
-            margin-bottom: 16px;
+            font-size: 14px;
+            line-height: 1.65;
+            color: var(--text-muted);
+            margin-bottom: 14px;
         }
 
         .team-story strong {
-            color: var(--text-primary);
+            color: var(--text);
+            font-weight: 600;
         }
 
         .video-wrapper {
             border-radius: 12px;
             overflow: hidden;
             background: #000;
+            border: 1px solid var(--border);
+            position: relative;
         }
 
         .video-hero {
@@ -1063,13 +1311,13 @@ KEY CHANGES:
 
         /* Footer */
         footer {
-            background: white;
+            background: var(--bg-elevated);
             padding: 60px 24px 32px;
             border-top: 1px solid var(--border);
         }
 
         .footer-content {
-            max-width: 1100px;
+            max-width: 1280px;
             margin: 0 auto;
         }
 
@@ -1081,25 +1329,27 @@ KEY CHANGES:
         }
 
         .footer-brand h3 {
-            font-size: 18px;
+            font-size: 16px;
             font-weight: 600;
             margin-bottom: 12px;
-            color: var(--text-primary);
+            color: var(--text);
+            letter-spacing: -0.02em;
         }
 
         .footer-brand p {
-            font-size: 15px;
+            font-size: 14px;
             line-height: 1.6;
-            color: var(--text-secondary);
+            color: var(--text-muted);
             max-width: 280px;
         }
 
         .footer-column h4 {
-            font-size: 13px;
-            font-weight: 600;
+            font-family: var(--font-mono);
+            font-size: 11px;
+            font-weight: 500;
             text-transform: uppercase;
-            letter-spacing: 0.5px;
-            color: var(--text-primary);
+            letter-spacing: 0.06em;
+            color: var(--text-dim);
             margin-bottom: 16px;
         }
 
@@ -1112,10 +1362,10 @@ KEY CHANGES:
         }
 
         .footer-column a {
-            color: var(--text-secondary);
+            color: var(--text-muted);
             text-decoration: none;
             font-size: 14px;
-            transition: color 0.2s ease;
+            transition: color 0.2s var(--ease);
         }
 
         .footer-column a:hover {
@@ -1123,14 +1373,16 @@ KEY CHANGES:
         }
 
         .footer-bottom {
-            padding-top: 32px;
+            padding-top: 28px;
             border-top: 1px solid var(--border);
             text-align: center;
         }
 
         .footer-bottom p {
-            font-size: 14px;
-            color: var(--text-tertiary);
+            font-family: var(--font-mono);
+            font-size: 12px;
+            color: var(--text-dim);
+            letter-spacing: 0.02em;
         }
 
         /* Mobile Sticky CTA */
@@ -1140,22 +1392,30 @@ KEY CHANGES:
             bottom: 0;
             left: 0;
             right: 0;
-            background: white;
-            padding: 12px 24px;
-            box-shadow: 0 -4px 20px rgba(0, 0, 0, 0.1);
+            background: rgba(7, 8, 12, 0.92);
+            backdrop-filter: blur(16px);
+            -webkit-backdrop-filter: blur(16px);
+            border-top: 1px solid var(--border);
+            padding: 12px 16px;
             z-index: 999;
+            transition: opacity 0.2s var(--ease);
         }
 
         .mobile-sticky-cta a {
             display: block;
             background: var(--accent);
-            color: white;
+            color: var(--bg);
             text-align: center;
-            padding: 14px;
-            border-radius: 100px;
+            padding: 13px;
+            border-radius: 8px;
             font-weight: 600;
-            font-size: 16px;
+            font-size: 15px;
             text-decoration: none;
+            transition: all 0.2s var(--ease);
+        }
+
+        .mobile-sticky-cta a:hover {
+            background: var(--text);
         }
 
         /* Mobile Menu */
@@ -1169,48 +1429,54 @@ KEY CHANGES:
 
         .menu-toggle span {
             display: block;
-            width: 24px;
+            width: 22px;
             height: 2px;
-            background: var(--text-primary);
+            background: var(--text);
             margin: 5px 0;
-            transition: all 0.3s ease;
+            transition: all 0.3s var(--ease);
+            border-radius: 2px;
         }
 
         .mobile-menu {
             position: absolute;
-            top: 72px;
-            right: 24px;
-            left: 24px;
-            background: white;
-            border-radius: 16px;
-            box-shadow: 0 8px 32px rgba(0, 0, 0, 0.12);
+            top: 64px;
+            right: 16px;
+            left: 16px;
+            background: rgba(17, 20, 28, 0.96);
+            backdrop-filter: blur(20px);
+            -webkit-backdrop-filter: blur(20px);
+            border: 1px solid var(--border);
+            border-radius: 12px;
+            box-shadow: 0 16px 48px rgba(0, 0, 0, 0.6);
             display: flex;
             flex-direction: column;
-            gap: 8px;
-            padding: 24px;
+            gap: 4px;
+            padding: 16px;
             z-index: 2000;
         }
 
         .mobile-menu a {
             text-decoration: none;
-            color: var(--text-primary);
-            font-size: 17px;
-            font-weight: 600;
-            padding: 12px 16px;
-            border-radius: 8px;
-            transition: background 0.2s, color 0.2s;
+            color: var(--text-muted);
+            font-size: 15px;
+            font-weight: 500;
+            padding: 11px 14px;
+            border-radius: 6px;
+            transition: all 0.2s var(--ease);
         }
 
         .mobile-menu a:hover {
-            background: var(--hover);
-            color: var(--accent);
+            background: rgba(255, 255, 255, 0.04);
+            color: var(--text);
         }
 
         .mobile-menu .nav-cta {
-            margin-top: 16px;
+            margin-top: 8px;
             text-align: center;
-            background: var(--accent);
-            color: white !important;
+            background: var(--accent) !important;
+            color: var(--bg) !important;
+            border: 1px solid var(--accent);
+            font-weight: 600;
         }
 
         /* Logo */
@@ -1219,32 +1485,37 @@ KEY CHANGES:
             align-items: center;
         }
 
-        .logo-img {
-            height: 48px;
-            background: #fff;
-            border-radius: 10px;
-            padding: 6px;
-            box-sizing: border-box;
+        .logo-mark {
+            display: block;
+            flex-shrink: 0;
+            transition: transform 0.3s var(--ease), filter 0.3s var(--ease);
+            filter: drop-shadow(0 0 12px rgba(46, 229, 197, 0.0));
+        }
+
+        .logo:hover .logo-mark {
+            transform: scale(1.05);
+            filter: drop-shadow(0 0 16px rgba(46, 229, 197, 0.35));
         }
 
         .logo-separator {
             width: 1px;
-            height: 40px;
-            background: #E5E5E5;
-            margin: 0 16px;
+            height: 22px;
+            background: var(--border-strong);
+            margin: 0 14px;
         }
 
         .logo-text {
-            font-size: 1.5rem;
+            font-size: 17px;
             font-weight: 600;
-            color: var(--text-primary);
+            color: var(--text);
+            letter-spacing: -0.02em;
         }
 
         /* Animations */
         @keyframes fadeInUp {
             from {
                 opacity: 0;
-                transform: translateY(24px);
+                transform: translateY(16px);
             }
             to {
                 opacity: 1;
@@ -1252,11 +1523,9 @@ KEY CHANGES:
             }
         }
 
-        /* Responsive Design */
+        /* Responsive */
         @media (max-width: 1024px) {
-            nav {
-                gap: 24px;
-            }
+            nav { gap: 20px; }
 
             .team-story-container {
                 grid-template-columns: 1fr;
@@ -1271,165 +1540,50 @@ KEY CHANGES:
                 grid-row: auto;
             }
 
-            .credentials-grid {
-                grid-template-columns: 1fr;
-            }
-
-            .team-values {
-                grid-template-columns: repeat(2, 1fr);
-            }
-
-            .approach-grid {
-                grid-template-columns: repeat(2, 1fr);
-            }
-
-            .outcomes-grid {
-                grid-template-columns: repeat(2, 1fr);
-            }
-
-            .footer-grid {
-                grid-template-columns: 1fr 1fr;
-                gap: 32px;
-            }
+            .credentials-grid { grid-template-columns: 1fr; }
+            .team-values { grid-template-columns: repeat(3, 1fr); }
+            .approach-grid { grid-template-columns: repeat(2, 1fr); }
+            .outcomes-grid { grid-template-columns: repeat(2, 1fr); }
+            .footer-grid { grid-template-columns: 1fr 1fr; gap: 32px; }
+            .company-names { gap: 28px; }
         }
 
         @media (max-width: 768px) {
-            .menu-toggle {
-                display: block;
-            }
-
-            nav {
-                display: none;
-            }
-
-            .mobile-sticky-cta {
-                display: block;
-            }
-
-            body {
-                padding-bottom: 80px;
-            }
-
-            .hero {
-                min-height: 85vh;
-            }
-
-            .hero h1 {
-                font-size: 36px !important;
-                line-height: 1.1;
-            }
-
-            .hero-description {
-                font-size: 17px;
-            }
-
-            .hero-actions {
-                flex-direction: column;
-                width: 100%;
-                gap: 12px;
-            }
-
-            .btn-primary,
-            .btn-secondary {
-                width: 100%;
-                justify-content: center;
-            }
-
-            .section {
-                padding: 60px 16px;
-            }
-
-            .section-header {
-                margin-bottom: 40px;
-            }
-
-            .grade-grid {
-                grid-template-columns: 1fr;
-            }
-
-            .competition-grid {
-                grid-template-columns: 1fr;
-            }
-
-            .competition-actions {
-                flex-direction: column;
-            }
-
-            .btn-light,
-            .btn-ghost {
-                width: 100%;
-                justify-content: center;
-            }
-
-            .approach-grid {
-                grid-template-columns: 1fr;
-            }
-
-            .progress-section {
-                padding: 32px 24px;
-            }
-
-            .progress-grid {
-                grid-template-columns: 1fr;
-            }
-
-            .outcomes-grid {
-                grid-template-columns: 1fr;
-            }
-
-            .showcase-grid {
-                grid-template-columns: 1fr 1fr;
-            }
-
-            .team-values {
-                grid-template-columns: 1fr;
-            }
-
-            .credentials-grid {
-                grid-template-columns: 1fr;
-            }
-
-            .company-names {
-                grid-template-columns: repeat(2, 1fr);
-                gap: 20px;
-            }
-
-            .company-text-bar {
-                padding: 24px 16px;
-            }
-
-            .registration-form {
-                padding: 24px 20px;
-            }
-
-            .footer-grid {
-                grid-template-columns: 1fr;
-                gap: 32px;
-            }
-
-            .logo-img {
-                height: 40px;
-            }
-
-            .logo-separator {
-                height: 32px;
-                margin: 0 12px;
-            }
-
-            .logo-text {
-                font-size: 1.25rem;
-            }
+            .menu-toggle { display: block; }
+            nav { display: none; }
+            .mobile-sticky-cta { display: block; }
+            body { padding-bottom: 80px; }
+            .hero { min-height: 88vh; padding-top: 100px; }
+            .hero h1 { font-size: 40px !important; line-height: 1.05; }
+            .hero-description { font-size: 16px; }
+            .hero-actions { flex-direction: column; width: 100%; gap: 10px; }
+            .btn-primary, .btn-secondary { width: 100%; justify-content: center; }
+            .section { padding: 64px 16px; }
+            .section-header { margin-bottom: 36px; }
+            .grade-grid { grid-template-columns: 1fr; }
+            .competition-grid { grid-template-columns: 1fr; }
+            .competition-actions { flex-direction: column; }
+            .btn-light, .btn-ghost { width: 100%; justify-content: center; }
+            .approach-grid { grid-template-columns: 1fr; }
+            .progress-section { padding: 32px 24px; }
+            .progress-grid { grid-template-columns: 1fr; }
+            .outcomes-grid { grid-template-columns: 1fr; }
+            .showcase-grid { grid-template-columns: 1fr 1fr; }
+            .team-values { grid-template-columns: 1fr; }
+            .credentials-grid { grid-template-columns: 1fr; }
+            .company-names { gap: 20px; }
+            .company-logo { max-height: 22px !important; }
+            .company-text-bar { padding: 28px 16px 22px; }
+            .registration-form { padding: 28px 20px; }
+            .footer-grid { grid-template-columns: 1fr; gap: 32px; }
+            .logo-mark { width: 32px; height: 32px; }
+            .logo-separator { height: 20px; margin: 0 12px; }
+            .logo-text { font-size: 15px; }
+            .nav-container { padding: 12px 16px; }
         }
 
         @media (min-width: 769px) {
-            .mobile-menu {
-                display: none !important;
-            }
-        }
-
-        /* Smooth Scroll */
-        html {
-            scroll-behavior: smooth;
+            .mobile-menu { display: none !important; }
         }
     </style>
 </head>
@@ -1437,26 +1591,147 @@ KEY CHANGES:
     <!-- Navigation -->
     <header>
         <div class="nav-container">
-            <a href="#" class="logo" id="logo-link">
+            <a href="#" class="logo" id="logo-link" aria-label="Genboo home">
                 <span class="logo-flex">
-                    <img src="assets/images/logo.jpg" alt="Genboo Logo" class="logo-img">
-                    <span class="logo-separator"></span>
+                    <!--
+                        LOGO VARIANTS — Genboo = 进步 (jìnbù, "progress / step forward")
+                        To swap: comment the active SVG block and uncomment another.
+                        See logos.html for a full side-by-side comparison.
+
+                        Chinese character marks (full brand origin):
+                          L) 进步 vertical stack    (active)  — full word, seal-style, two-tone teal/blue
+                          G) 步 Chinese character mark        — single "step" character
+                          M) 进 Chinese character mark        — single "advance" character
+                          N) 进步 horizontal micro-wordmark    — both characters side-by-side
+                          O) 进 + chevron echo hybrid          — character with forward-motion gesture
+
+                        Progress-themed marks (inspired by 进步):
+                          D) Stepped path with arrow         — staircase climbing up-right
+                          E) Stacked pyramid + star          — blocks rising toward a goal
+                          F) Sprout + foundation             — organic growth, kids-friendly
+                          H) Ascending chevron pair          — diagonal climb (forward + up)
+                          I) Triple chevron crescendo        — momentum building right
+                          J) Chevron + milestone target      — advancing toward a clear goal
+                          K) Triple chevron marching up      — elevation + momentum combined
+
+                        Brand-mark variants:
+                          A) Geometric "G" monogram          — mirrors tier badges (I / II / III)
+                          B) Modular 3x3 node grid           — neural-net / AI feel
+                          C) Double chevron `>>`              — code-cursor / forward-momentum feel
+                    -->
+
+                    <!-- Variant D: Stepped progress path (alternative) — 进步 as climbing steps
+                    <svg width="36" height="36" viewBox="0 0 36 36" fill="none" xmlns="http://www.w3.org/2000/svg" class="logo-mark" aria-hidden="true">
+                        <rect x="0.5" y="0.5" width="35" height="35" rx="8" fill="rgba(46, 229, 197, 0.08)" stroke="rgba(46, 229, 197, 0.22)" stroke-width="1"/>
+                        <path d="M 8 27 L 8 22 L 14 22 L 14 17 L 20 17 L 20 12 L 28 12"
+                              stroke="#2EE5C5" stroke-width="2.4" fill="none"
+                              stroke-linecap="round" stroke-linejoin="round"/>
+                        <path d="M 25 9 L 28 12 L 25 15"
+                              stroke="#38BDF8" stroke-width="2.4" fill="none"
+                              stroke-linecap="round" stroke-linejoin="round"/>
+                    </svg>
+                    -->
+
+                    <!-- Variant E: Stacked pyramid + star (alternative) — building blocks rising toward a goal
+                    <svg width="36" height="36" viewBox="0 0 36 36" fill="none" xmlns="http://www.w3.org/2000/svg" class="logo-mark" aria-hidden="true">
+                        <rect x="0.5" y="0.5" width="35" height="35" rx="8" fill="rgba(46, 229, 197, 0.08)" stroke="rgba(46, 229, 197, 0.22)" stroke-width="1"/>
+                        <rect x="8" y="23" width="20" height="4" rx="1" fill="#2EE5C5" opacity="0.5"/>
+                        <rect x="11" y="17" width="14" height="4" rx="1" fill="#2EE5C5" opacity="0.75"/>
+                        <rect x="14" y="11" width="8" height="4" rx="1" fill="#2EE5C5"/>
+                        <circle cx="18" cy="7" r="2" fill="#38BDF8"/>
+                        <circle cx="18" cy="7" r="3.6" fill="#38BDF8" opacity="0.25"/>
+                    </svg>
+                    -->
+
+                    <!-- LOGO MARK CURRENTLY DISABLED — wordmark only. To re-enable, uncomment one variant below. -->
+
+                    <!-- Variant L: 进步 vertical stack (alternative) — full Chinese word, seal-style, two-tone teal/blue
+                    <svg width="36" height="36" viewBox="0 0 36 36" fill="none" xmlns="http://www.w3.org/2000/svg" class="logo-mark" role="img" aria-label="Genboo 进步">
+                        <rect x="0.5" y="0.5" width="35" height="35" rx="8" fill="rgba(46, 229, 197, 0.08)" stroke="rgba(46, 229, 197, 0.22)" stroke-width="1"/>
+                        <text x="18" y="17" text-anchor="middle"
+                              font-family="'PingFang SC', 'Hiragino Sans GB', 'Noto Sans CJK SC', 'Microsoft YaHei', 'WenQuanYi Micro Hei', sans-serif"
+                              font-weight="700" font-size="14" fill="#2EE5C5">进</text>
+                        <text x="18" y="32" text-anchor="middle"
+                              font-family="'PingFang SC', 'Hiragino Sans GB', 'Noto Sans CJK SC', 'Microsoft YaHei', 'WenQuanYi Micro Hei', sans-serif"
+                              font-weight="700" font-size="14" fill="#38BDF8">步</text>
+                    </svg>
+                    -->
+
+                    <!-- Variant F: Sprout growing from a foundation (alternative) — organic growth, kids becoming engineers
+                    <svg width="36" height="36" viewBox="0 0 36 36" fill="none" xmlns="http://www.w3.org/2000/svg" class="logo-mark" aria-hidden="true">
+                        <rect x="0.5" y="0.5" width="35" height="35" rx="8" fill="rgba(46, 229, 197, 0.08)" stroke="rgba(46, 229, 197, 0.22)" stroke-width="1"/>
+                        <rect x="9" y="26" width="18" height="2" rx="1" fill="#2EE5C5" opacity="0.45"/>
+                        <path d="M 18 27 L 18 14" stroke="#2EE5C5" stroke-width="2" stroke-linecap="round"/>
+                        <path d="M 18 18 C 13 17 10 14 10 9 C 15 10 18 13 18 18 Z" fill="#2EE5C5"/>
+                        <path d="M 18 14 C 23 13 26 10 26 5 C 21 6 18 9 18 14 Z" fill="#38BDF8"/>
+                    </svg>
+                    -->
+
+                    <!-- Variant G: 步 Chinese character (alternative) — direct cultural homage to 进步
+                    <svg width="36" height="36" viewBox="0 0 36 36" fill="none" xmlns="http://www.w3.org/2000/svg" class="logo-mark" aria-hidden="true">
+                        <rect x="0.5" y="0.5" width="35" height="35" rx="8" fill="rgba(46, 229, 197, 0.08)" stroke="rgba(46, 229, 197, 0.22)" stroke-width="1"/>
+                        <text x="18" y="27" text-anchor="middle"
+                              font-family="'PingFang SC', 'Hiragino Sans GB', 'Noto Sans CJK SC', 'Microsoft YaHei', 'WenQuanYi Micro Hei', sans-serif"
+                              font-weight="600" font-size="22" fill="#2EE5C5">步</text>
+                    </svg>
+                    -->
+
+                    <!-- Variant A: Geometric G monogram (alternative)
+                    <svg width="36" height="36" viewBox="0 0 36 36" fill="none" xmlns="http://www.w3.org/2000/svg" class="logo-mark" aria-hidden="true">
+                        <rect x="0.5" y="0.5" width="35" height="35" rx="8" fill="rgba(46, 229, 197, 0.08)" stroke="rgba(46, 229, 197, 0.22)" stroke-width="1"/>
+                        <g fill="#2EE5C5">
+                            <rect x="9" y="10" width="18" height="3" rx="0.75"/>
+                            <rect x="9" y="10" width="3" height="16" rx="0.75"/>
+                            <rect x="9" y="23" width="18" height="3" rx="0.75"/>
+                            <rect x="24" y="18" width="3" height="8" rx="0.75"/>
+                            <rect x="17" y="18" width="10" height="3" rx="0.75"/>
+                        </g>
+                    </svg>
+                    -->
+
+                    <!-- Variant B: Modular 3x3 node grid (alternative)
+                    <svg width="36" height="36" viewBox="0 0 36 36" fill="none" xmlns="http://www.w3.org/2000/svg" class="logo-mark" aria-hidden="true">
+                        <rect x="0.5" y="0.5" width="35" height="35" rx="8" fill="rgba(46, 229, 197, 0.06)" stroke="rgba(46, 229, 197, 0.2)" stroke-width="1"/>
+                        <line x1="11" y1="11" x2="25" y2="11" stroke="#2A3344" stroke-width="0.75"/>
+                        <line x1="11" y1="18" x2="25" y2="18" stroke="#2A3344" stroke-width="0.75"/>
+                        <line x1="11" y1="25" x2="25" y2="25" stroke="#2A3344" stroke-width="0.75"/>
+                        <line x1="11" y1="11" x2="11" y2="25" stroke="#2A3344" stroke-width="0.75"/>
+                        <line x1="18" y1="11" x2="18" y2="25" stroke="#2A3344" stroke-width="0.75"/>
+                        <line x1="25" y1="11" x2="25" y2="25" stroke="#2A3344" stroke-width="0.75"/>
+                        <circle cx="11" cy="11" r="2" fill="#2A3344"/>
+                        <circle cx="18" cy="11" r="2.4" fill="#2EE5C5"/>
+                        <circle cx="25" cy="11" r="2" fill="#2A3344"/>
+                        <circle cx="11" cy="18" r="2.4" fill="#2EE5C5"/>
+                        <circle cx="18" cy="18" r="3" fill="#38BDF8"/>
+                        <circle cx="25" cy="18" r="2.4" fill="#2EE5C5"/>
+                        <circle cx="11" cy="25" r="2" fill="#2A3344"/>
+                        <circle cx="18" cy="25" r="2.4" fill="#2EE5C5"/>
+                        <circle cx="25" cy="25" r="2" fill="#2A3344"/>
+                    </svg>
+                    -->
+
+                    <!-- Variant C: Double chevron (alternative)
+                    <svg width="36" height="36" viewBox="0 0 36 36" fill="none" xmlns="http://www.w3.org/2000/svg" class="logo-mark" aria-hidden="true">
+                        <rect x="0.5" y="0.5" width="35" height="35" rx="8" fill="rgba(46, 229, 197, 0.08)" stroke="rgba(46, 229, 197, 0.22)" stroke-width="1"/>
+                        <path d="M 10 11 L 17 18 L 10 25" stroke="#2EE5C5" stroke-width="2.6" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+                        <path d="M 19 11 L 26 18 L 19 25" stroke="#38BDF8" stroke-width="2.6" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+                    </svg>
+                    -->
+
                     <span class="logo-text">Genboo</span>
                 </span>
             </a>
             <nav>
-                <a href="#about">About Us</a>
+                <a href="#about">About</a>
                 <a href="#programs">Programs</a>
                 <a href="#competition">Competition Team</a>
-                <a href="#consulting">Tech Consulting</a>
                 <a href="#faq">FAQ</a>
                 <a href="#register" class="nav-cta">Register</a>
             </nav>
             <div class="mobile-menu" id="mobileMenu" style="display: none;">
-                <a href="#about">About Us</a>
+                <a href="#about">About</a>
                 <a href="#programs">Programs</a>
                 <a href="#competition">Competition Team</a>
-                <a href="#consulting">Tech Consulting</a>
                 <a href="#faq">FAQ</a>
                 <a href="#register" class="nav-cta">Register</a>
             </div>
@@ -1480,24 +1755,28 @@ KEY CHANGES:
         </div>
 
         <div class="hero-content">
+            <div class="hero-badge">
+                <span class="hero-badge-dot"></span>
+                Bay Area · Robotics + AI Studio for Young Engineers
+            </div>
             <h1>Build. <span class="gradient-text">Code.</span> Create.</h1>
             <p class="hero-description">
                 A hands-on robotics and AI studio in the Bay Area. Small groups, learning-science-driven curriculum, and real engineering skills—built by researchers and parents who care.
             </p>
             <div class="hero-actions">
                 <a href="#programs" class="btn-secondary">See Programs</a>
-                <a href="#register" class="btn-primary">Register Now</a>
+                <a href="#register" class="btn-primary">Register Now →</a>
             </div>
         </div>
     </section>
 
     <!-- About Section -->
-    <section id="about" class="section" style="background: var(--secondary);">
+    <section id="about" class="section">
         <div class="section-header">
             <p class="section-label">Our Team</p>
-            <h2>Experienced Builders in AI & Robotics</h2>
+            <h2>Experienced builders in AI &amp; robotics.</h2>
             <p class="section-description">
-                We're a team of AI and robotics researchers, engineers, and designers—<strong>and parents with kids of our own</strong>—bringing over a decade of experience from leading universities and top tech companies. We're here to turn cutting-edge technology into playful, engaging, and skill-building experiences that we'd want for our own children.
+                We're a team of AI and robotics researchers, engineers, and designers—<strong>and parents with kids of our own</strong>—bringing over a decade of experience from leading universities and top tech companies. We turn cutting-edge technology into playful, engaging, skill-building experiences we'd want for our own children.
             </p>
         </div>
 
@@ -1505,33 +1784,33 @@ KEY CHANGES:
         <div class="credentials-showcase">
             <div class="company-text-bar">
                 <div class="company-names">
-                    <img src="assets/images/nvidia-logo.png" alt="NVIDIA" class="company-logo" style="height: 16px;">
-                    <img src="assets/images/google-logo.png" alt="Google" class="company-logo" style="height: 20px;">
-                    <img src="assets/images/tesla-logo.png" alt="Tesla" class="company-logo" style="height: 44px;">
-                    <img src="assets/images/cmu-logo.png" alt="Carnegie Mellon University" class="company-logo" style="height: 16px;">
-                    <img src="assets/images/meta-logo.png" alt="Meta" class="company-logo" style="height: 12px;">
-                    <img src="assets/images/stanford-logo.png" alt="Stanford University" class="company-logo" style="height: 24px;">
-                    <img src="assets/images/thu-logo.png" alt="Tsinghua University" class="company-logo" style="height: 24px;">
-                    <img src="assets/images/sjtu-logo.png" alt="Shanghai Jiao Tong University" class="company-logo" style="height: 24px;">
+                    <img src="assets/images/nvidia-logo.png" alt="NVIDIA" class="company-logo">
+                    <img src="assets/images/google-logo.png" alt="Google" class="company-logo">
+                    <img src="assets/images/tesla-logo.png" alt="Tesla" class="company-logo">
+                    <img src="assets/images/cmu-logo.png" alt="Carnegie Mellon University" class="company-logo">
+                    <img src="assets/images/meta-logo.png" alt="Meta" class="company-logo">
+                    <img src="assets/images/stanford-logo.png" alt="Stanford University" class="company-logo">
+                    <img src="assets/images/thu-logo.png" alt="Tsinghua University" class="company-logo">
+                    <img src="assets/images/sjtu-logo.png" alt="Shanghai Jiao Tong University" class="company-logo">
                 </div>
             </div>
 
             <div class="credentials-grid">
                 <div class="credential-card">
                     <h4>PhD in Robotics Research</h4>
-                    <p>Advanced degrees in robotics and AI from Carnegie Mellon University, Stanford University, and Shanghai Jiao Tong University</p>
+                    <p>Advanced degrees in robotics and AI from Carnegie Mellon University, Stanford University, and Shanghai Jiao Tong University.</p>
                 </div>
                 <div class="credential-card">
                     <h4>Tech Industry Veterans</h4>
-                    <p>AI researchers from NVIDIA, Google, Tesla, Apple, and Carnegie Mellon University with years of cutting-edge experience</p>
+                    <p>AI researchers from NVIDIA, Google, Tesla, Apple, and Carnegie Mellon University with years of cutting-edge experience.</p>
                 </div>
                 <div class="credential-card">
-                    <h4>AI & UX Design Experts</h4>
-                    <p>Human-centered design for AI products and educational experiences that kids actually love</p>
+                    <h4>AI &amp; UX Design Experts</h4>
+                    <p>Human-centered design for AI products and educational experiences that kids actually love.</p>
                 </div>
                 <div class="credential-card">
                     <h4>Published Research</h4>
-                    <p>Machine learning and robotics research at top-tier conferences</p>
+                    <p>Machine learning and robotics research at top-tier conferences.</p>
                 </div>
             </div>
 
@@ -1545,7 +1824,7 @@ KEY CHANGES:
                     <p>Our curriculum draws from learning science research, not just robotics trends. We apply what actually works.</p>
                 </div>
                 <div class="team-value">
-                    <h4>Safety & Supervision</h4>
+                    <h4>Safety &amp; Supervision</h4>
                     <p>Small groups with 1:4 ratios. Clear protocols for tools and equipment. Your child's safety is non-negotiable.</p>
                 </div>
             </div>
@@ -1596,10 +1875,10 @@ KEY CHANGES:
     </section>
 
     <!-- Learning Approach Section -->
-    <section id="approach" class="section" style="background: var(--secondary);">
+    <section id="approach" class="section">
         <div class="section-header">
             <p class="section-label">Learning Approach</p>
-            <h2>How Kids Actually Learn Engineering</h2>
+            <h2>How kids actually learn engineering.</h2>
             <p class="section-description">
                 Our curriculum is grounded in learning science—not just robotics trends. Every session is designed around how kids build understanding, not just what they build.
             </p>
@@ -1657,10 +1936,10 @@ KEY CHANGES:
     </section>
 
     <!-- Programs Section -->
-    <section id="programs" class="section" style="background: var(--secondary);">
+    <section id="programs" class="section">
         <div class="section-header">
             <p class="section-label">Our Programs</p>
-            <h2>Robotics for Every Young Engineer</h2>
+            <h2>Robotics for every young engineer.</h2>
             <p class="section-description">
                 From first-time builders to aspiring competitors, our grade-banded programs meet kids where they are. Small groups, hands-on projects, and real engineering skills that transfer beyond any single platform.
             </p>
@@ -1668,13 +1947,13 @@ KEY CHANGES:
 
         <div class="programs-container">
             <div class="grade-grid">
-                <!-- Grade 1 -->
+                <!-- Intro tier -->
                 <div class="grade-card">
                     <div class="grade-card-header">
-                        <div class="grade-icon">G1</div>
+                        <div class="grade-icon">I</div>
                         <div>
-                            <h4>Grade 1</h4>
-                            <span class="grade-badge">Ages 6–7 • Beginner</span>
+                            <h4>Intro</h4>
+                            <span class="grade-badge">Ages 6–7</span>
                         </div>
                     </div>
                     <div class="grade-details">
@@ -1700,13 +1979,13 @@ KEY CHANGES:
                     </div>
                 </div>
 
-                <!-- Grade 2 -->
+                <!-- Intermediate tier -->
                 <div class="grade-card">
                     <div class="grade-card-header">
-                        <div class="grade-icon">G2</div>
+                        <div class="grade-icon">II</div>
                         <div>
-                            <h4>Grade 2</h4>
-                            <span class="grade-badge">Ages 7–8 • Intermediate</span>
+                            <h4>Intermediate</h4>
+                            <span class="grade-badge">Ages 7–8</span>
                         </div>
                     </div>
                     <div class="grade-details">
@@ -1732,13 +2011,13 @@ KEY CHANGES:
                     </div>
                 </div>
 
-                <!-- Grade 3+ -->
+                <!-- Advanced tier -->
                 <div class="grade-card">
                     <div class="grade-card-header">
-                        <div class="grade-icon">G3+</div>
+                        <div class="grade-icon">III</div>
                         <div>
-                            <h4>Grade 3+</h4>
-                            <span class="grade-badge">Ages 8–12 • Advanced</span>
+                            <h4>Advanced</h4>
+                            <span class="grade-badge">Ages 8–12</span>
                         </div>
                     </div>
                     <div class="grade-details">
@@ -1769,10 +2048,10 @@ KEY CHANGES:
     </section>
 
     <!-- Competition Team Section -->
-    <section id="competition" class="section" style="background: var(--secondary);">
+    <section id="competition" class="section">
         <div class="section-header">
             <p class="section-label">Competition Team</p>
-            <h2>Structured Competition Team</h2>
+            <h2>Structured competition team.</h2>
             <p class="section-description">
                 This is not a drop-in class—it's a team. Students commit to a full competition season, building skills through consistent practice, iteration, and real tournament experience.
             </p>
@@ -1798,113 +2077,15 @@ KEY CHANGES:
         </div>
 
         <div class="competition-actions">
-            <a href="#register" class="btn-light">Apply / Join Waitlist</a>
-        </div>
-    </section>
-
-    <!-- Tech Consulting Section -->
-    <section id="consulting" class="section">
-        <div class="section-header">
-            <p class="section-label">For Parents & Teams</p>
-            <h2>Technical Support & Consulting</h2>
-            <p class="section-description">
-                Already have a robotics team or competing in another program? Our engineers can help. We offer technical consulting and support for parents and teams who need expert guidance.
-            </p>
-        </div>
-
-        <div class="programs-container">
-            <div class="grade-grid">
-                <div class="grade-card">
-                    <div class="grade-card-header">
-                        <div>
-                            <h4>Technical Support</h4>
-                            <span class="grade-badge">Hourly Sessions</span>
-                        </div>
-                    </div>
-                    <div class="grade-section grade-section-offer">
-                        <p class="grade-section-title">What We Offer</p>
-                        <ul>
-                            <li>Robot debugging and troubleshooting</li>
-                            <li>Code review and optimization</li>
-                            <li>Mechanical design feedback</li>
-                            <li>Sensor and autonomous routine help</li>
-                            <li>Pre-tournament tune-ups</li>
-                        </ul>
-                    </div>
-                    <div class="grade-section">
-                        <p class="grade-section-title">Best For</p>
-                        <ul>
-                            <li>Parent-coached teams needing expert advice</li>
-                            <li>Teams stuck on a specific technical problem</li>
-                            <li>Last-minute competition prep</li>
-                        </ul>
-                    </div>
-                </div>
-
-                <div class="grade-card">
-                    <div class="grade-card-header">
-                        <div>
-                            <h4>Strategy Consulting</h4>
-                            <span class="grade-badge">Package Available</span>
-                        </div>
-                    </div>
-                    <div class="grade-section grade-section-offer">
-                        <p class="grade-section-title">What We Offer</p>
-                        <ul>
-                            <li>Season planning and goal-setting</li>
-                            <li>Game analysis and strategy development</li>
-                            <li>Team structure and role optimization</li>
-                        </ul>
-                    </div>
-                    <div class="grade-section">
-                        <p class="grade-section-title">Best For</p>
-                        <ul>
-                            <li>New teams getting started</li>
-                            <li>Teams looking to level up</li>
-                            <li>Parents wanting to support more effectively</li>
-                        </ul>
-                    </div>
-                </div>
-
-                <div class="grade-card">
-                    <div class="grade-card-header">
-                        <div>
-                            <h4>Workshops</h4>
-                            <span class="grade-badge">Group Sessions</span>
-                        </div>
-                    </div>
-                    <div class="grade-section grade-section-offer">
-                        <p class="grade-section-title">What We Offer</p>
-                        <ul>
-                            <li>Parent training sessions</li>
-                            <li>Team skill-building workshops</li>
-                            <li>Programming bootcamps</li>
-                            <li>Mechanical systems deep-dives</li>
-                            <li>Competition preparation clinics</li>
-                        </ul>
-                    </div>
-                    <div class="grade-section">
-                        <p class="grade-section-title">Best For</p>
-                        <ul>
-                            <li>Groups of teams wanting shared training</li>
-                            <li>Schools or clubs building programs</li>
-                            <li>Parent groups coordinating support</li>
-                        </ul>
-                    </div>
-                </div>
-            </div>
-
-            <div style="text-align: center; margin-top: 40px;">
-                <a href="mailto:hello@genboo.com?subject=Technical Consulting Inquiry" class="btn-primary">Get in Touch</a>
-            </div>
+            <a href="#register" class="btn-light">Apply / Join Waitlist →</a>
         </div>
     </section>
 
     <!-- Outcomes Section -->
-    <section id="outcomes" class="section" style="background: var(--secondary);">
+    <section id="outcomes" class="section">
         <div class="section-header">
             <p class="section-label">Outcomes</p>
-            <h2>What Your Child Will Be Able to Do</h2>
+            <h2>What your child will be able to do.</h2>
             <p class="section-description">
                 Our learning goals focus on real, demonstrable skills—not just "exposure to STEM."
             </p>
@@ -1921,7 +2102,7 @@ KEY CHANGES:
             </div>
             <div class="outcome-item">
                 <h4>Design Reasoning</h4>
-                <p>Explain decisions with evidence ("I chose this because...").</p>
+                <p>Explain decisions with evidence ("I chose this because…").</p>
             </div>
             <div class="outcome-item">
                 <h4>Systematic Debugging</h4>
@@ -1943,7 +2124,7 @@ KEY CHANGES:
     <section id="faq" class="section">
         <div class="section-header">
             <p class="section-label">FAQ</p>
-            <h2>Common Questions</h2>
+            <h2>Common questions.</h2>
         </div>
 
         <div class="faq-container">
@@ -1953,7 +2134,7 @@ KEY CHANGES:
                     <span class="faq-icon">+</span>
                 </button>
                 <div class="faq-answer">
-                    <p>Perfect—most kids start with us at zero experience. Our Grade 1 and Grade 2 programs are designed for complete beginners. We use screen-free, hands-on approaches that build confidence before introducing programming concepts.</p>
+                    <p>Perfect—most kids start with us at zero experience. Our Intro and Intermediate programs welcome complete beginners. We use screen-free, hands-on approaches that build confidence before introducing programming concepts.</p>
                 </div>
             </div>
 
@@ -2040,16 +2221,16 @@ KEY CHANGES:
     </section>
 
     <!-- Registration Section -->
-    <section id="register" class="section" style="background: var(--secondary);">
-        <div class="section-header">
-            <p class="section-label">Register</p>
-            <h2>Join Genboo Robotics</h2>
-            <p class="section-description">Fill out the form below to register or join our waitlist. We'll be in touch within 24 hours.</p>
+    <section id="register" class="section">
+        <div class="section-header" style="text-align: center; margin-left: auto; margin-right: auto;">
+            <p class="section-label" style="justify-content: center;">Register</p>
+            <h2 style="margin-left: auto; margin-right: auto;">Join Genboo Robotics.</h2>
+            <p class="section-description" style="margin-left: auto; margin-right: auto;">Fill out the form below to register or join our waitlist. We'll be in touch within 24 hours.</p>
         </div>
 
         <form class="registration-form" action="https://formspree.io/f/xqabbeeb" method="POST">
             <div class="form-group">
-                <label for="name">Parent/Guardian Name</label>
+                <label for="name">Parent / Guardian Name</label>
                 <input type="text" id="name" name="name" required>
             </div>
 
@@ -2067,17 +2248,12 @@ KEY CHANGES:
                 <label for="program">Program</label>
                 <select id="program" name="program" required>
                     <optgroup label="Programs">
-                        <option value="Program - Grade 1 (Ages 6-7)">Grade 1 (Ages 6–7)</option>
-                        <option value="Program - Grade 2 (Ages 7-8)">Grade 2 (Ages 7–8)</option>
-                        <option value="Program - Grade 3+ (Ages 8-12)">Grade 3+ (Ages 8–12)</option>
+                        <option value="Program - Intro (Ages 6-7)">Intro (Ages 6–7)</option>
+                        <option value="Program - Intermediate (Ages 7-8)">Intermediate (Ages 7–8)</option>
+                        <option value="Program - Advanced (Ages 8-12)">Advanced (Ages 8–12)</option>
                     </optgroup>
                     <optgroup label="Competition">
                         <option value="Competition Team - Apply">Competition Team — Apply</option>
-                    </optgroup>
-                    <optgroup label="Tech Consulting">
-                        <option value="Tech Consulting - Technical Support">Technical Support</option>
-                        <option value="Tech Consulting - Strategy Consulting">Strategy Consulting</option>
-                        <option value="Tech Consulting - Workshops">Workshops</option>
                     </optgroup>
                 </select>
             </div>
@@ -2100,7 +2276,7 @@ KEY CHANGES:
             <!-- Honeypot -->
             <input type="text" name="_gotcha" style="display:none" tabindex="-1" autocomplete="off">
 
-            <button type="submit" class="form-submit">Submit Registration</button>
+            <button type="submit" class="form-submit">Submit Registration →</button>
 
             <p class="schedule-note">Contact us for current schedule and pricing: <a href="mailto:hello@genboo.com" style="color: var(--accent);">hello@genboo.com</a></p>
         </form>
@@ -2119,7 +2295,6 @@ KEY CHANGES:
                     <ul>
                         <li><a href="#programs">Programs</a></li>
                         <li><a href="#competition">Competition Team</a></li>
-                        <li><a href="#consulting">Tech Consulting</a></li>
                     </ul>
                 </div>
                 <div class="footer-column">
@@ -2137,14 +2312,14 @@ KEY CHANGES:
                 </div>
             </div>
             <div class="footer-bottom">
-                <p>&copy; 2025-2026 Genboo Robotics. Building tomorrow's engineers.</p>
+                <p>© 2025–2026 GENBOO ROBOTICS · BUILDING TOMORROW'S ENGINEERS</p>
             </div>
         </div>
     </footer>
 
     <!-- Mobile Sticky CTA -->
     <div class="mobile-sticky-cta">
-        <a href="#register">Register Now</a>
+        <a href="#register">Register Now →</a>
     </div>
 
     <script>
@@ -2196,12 +2371,12 @@ KEY CHANGES:
             button.addEventListener('click', () => {
                 const item = button.parentElement;
                 const isActive = item.classList.contains('active');
-                
+
                 // Close all other items
                 document.querySelectorAll('.faq-item').forEach(i => {
                     i.classList.remove('active');
                 });
-                
+
                 // Toggle current item
                 if (!isActive) {
                     item.classList.add('active');
@@ -2226,7 +2401,7 @@ KEY CHANGES:
             let currentFrameIndex = 0;
             const videoBgContainer = document.querySelector('.video-background');
             if (videoBgContainer) {
-                videoBgContainer.innerHTML = `<img src="${frames[currentFrameIndex]}" alt="Background" style="max-width:100%;height:100%;object-fit:cover;position:absolute;top:0;left:0;">` +
+                videoBgContainer.innerHTML = `<img src="${frames[currentFrameIndex]}" alt="Background" style="max-width:100%;height:100%;object-fit:cover;position:absolute;top:0;left:0;opacity:0.32;filter:saturate(0.6) contrast(1.15) brightness(0.9);">` +
                     '<div class="video-overlay"></div>';
                 setInterval(() => {
                     currentFrameIndex = (currentFrameIndex + 1) % frames.length;
@@ -2238,7 +2413,7 @@ KEY CHANGES:
             const playBtn1 = document.getElementById('playDemoBtn1');
             const playBtn2 = document.getElementById('playDemoBtn2');
             const playBtn3 = document.getElementById('playDemoBtn3');
-            
+
             if (playBtn1 && playBtn2 && playBtn3) {
                 playBtn1.style.display = 'block';
                 playBtn2.style.display = 'block';
@@ -2273,7 +2448,7 @@ KEY CHANGES:
         // Hide mobile sticky CTA when near registration section
         const mobileCta = document.querySelector('.mobile-sticky-cta');
         const registerSection = document.getElementById('register');
-        
+
         if (mobileCta && registerSection) {
             window.addEventListener('scroll', () => {
                 const registerRect = registerSection.getBoundingClientRect();


### PR DESCRIPTION
Main site (genboo.com):
- Full dark-mode redesign: pitch-black palette, electric teal accent, Inter + JetBrains Mono typography, bento-grid layouts, subtle radial glows, glassmorphism navigation, snappy 0.2s transitions.
- Hero: glowing pulse-dot badge, massive headline, two-tone gradient on "Code.", ghost + solid CTAs.
- Programs: renamed G1/G2/G3+ tiers to Intro / Intermediate / Advanced with Roman numeral badges (I / II / III). Dropped redundant "Beginner/Intermediate/Advanced" line from meta — heading carries the tier name now.
- Removed Tech Consulting section entirely (nav, footer link, and registration dropdown options all cleaned up).
- Partner logos: monochrome inverted on the dark surface.
- FAQ accordion, registration form, mobile sticky CTA all restyled.
- Logo mark currently disabled (wordmark-only). 15 candidate SVG marks preserved as commented alternatives in nav for easy swap.

Humanoid subsite (humanoid/):
- Standalone page intended for humanoid.genboo.com.
- Same design system. Deployable via Cloudflare Pages from this same repo with a different build root.