### PR TITLE
Add Cloudflare wrangler configs for both subdomains

### DIFF
--- a/humanoid/wrangler.toml
+++ b/humanoid/wrangler.toml
@@ -1,0 +1,8 @@
+name = "genboo-humanoid"
+compatibility_date = "2024-11-01"
+
+# Cloudflare Workers Static Assets — serves the humanoid subsite from the humanoid/ folder.
+# Deploys to humanoid.genboo.com (custom domain configured in Cloudflare dashboard).
+[assets]
+directory = "./"
+not_found_handling = "404-page"

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,0 +1,8 @@
+name = "genboo-www"
+compatibility_date = "2024-11-01"
+
+# Cloudflare Workers Static Assets — serves the main Genboo site from the repo root.
+# Deploys to www.genboo.com (custom domain configured in Cloudflare dashboard).
+[assets]
+directory = "./"
+not_found_handling = "404-page"


### PR DESCRIPTION
- wrangler.toml at repo root: deploys main site to www.genboo.com
- humanoid/wrangler.toml: deploys humanoid subsite to humanoid.genboo.com

Both use Workers Static Assets to serve static files from the repo.